### PR TITLE
counterpart of jasp-stats/jasp-desktop#4244

### DIFF
--- a/R/ancova.R
+++ b/R/ancova.R
@@ -143,33 +143,59 @@ Ancova <- function(jaspResults, dataset = NULL, options) {
 
   modelTerms <- unlist(options$modelTerms, recursive = FALSE)
   factorModelTerms <- options$modelTerms[sapply(modelTerms, function(x) !any(x %in% options$covariates))]
+  allComponents <- unique(unlist(lapply(factorModelTerms, `[[`, "components"), use.names = FALSE))
 
-  for(i in length(factorModelTerms):1) {
-    .hasErrors(
-      dataset = dataset, 
-      type = c('observations', 'variance', 'infinity', 'factorLevels'),
-      all.target = c(options$dependent, options$covariates), 
-      all.grouping = factorModelTerms[[i]][['components']],
-      factorLevels.amount  = "< 2",
-      observations.amount = paste("<", length(options$dependent)+1), 
-      exitAnalysisIfErrors = TRUE)
-  }
-  
-  for(i in length(factorModelTerms):1) {
-    .hasErrors(
-      dataset = dataset, 
-      type = c('infinity', 'factorLevels'),
-      all.target = factorModelTerms[[i]][['components']], 
-      factorLevels.amount  = "< 2",
-      exitAnalysisIfErrors = TRUE)
-  }
-  
   .hasErrors(
-    dataset = dataset, 
-    type = c('infinity'),
-    all.target = options$wlsWeights,
-    exitAnalysisIfErrors = TRUE)
-  
+    dataset              = dataset,
+    type                 = c("infinity", "factorLevels"),
+    infinity.target      = c(options$dependent, options$covariates, allComponents, options$wlsWeights),
+    factorLevels.target  = options[["fixedFactors"]],
+    factorLevels.amount  = "< 2",
+    exitAnalysisIfErrors = TRUE
+  )
+
+  nWayInteractions <- unlist(lapply(factorModelTerms, lengths), use.names = FALSE)
+  if (any(nWayInteractions > 1L)) {
+
+    # ensure that the largest n-way interaction effects come last
+    factorModelTerms <- factorModelTerms[order(nWayInteractions)]
+
+    # For each model term, check if it is a strict subset of another term.
+    # For example, if grouping on a three-way interaction doesn't violate any error checks
+    # then all the two-way interactions composed of variables from the three-way interaction will pass.
+    idxToRemove <- integer()
+    for (i in 1:(length(factorModelTerms) - 1)) {
+      for (j in length(factorModelTerms):(i + 1)) {
+
+        if (all(factorModelTerms[[i]][["components"]] %in% factorModelTerms[[j]][["components"]])) {
+          idxToRemove <- c(idxToRemove, i)
+          break
+        }
+
+      }
+    }
+    componentsToGroupOn <- factorModelTerms[-idxToRemove]
+
+  } else {
+    componentsToGroupOn <- factorModelTerms
+  }
+
+  observations.amount <- paste("<", length(options[["dependent"]]) + 1L)
+  for(i in rev(seq_along(componentsToGroupOn))) {
+
+    componentsToGroupBy <- componentsToGroupOn[[i]][["components"]]
+
+    .hasErrors(
+      dataset              = dataset,
+      type                 = c("observations", "variance"),
+      all.target           = c(options$dependent, options$covariates),
+      all.grouping         = componentsToGroupBy,
+      observations.amount  = observations.amount,
+      exitAnalysisIfErrors = TRUE
+    )
+
+  }
+
   .hasErrors(dataset = dataset, 
              custom = function() {
                if (any(dataset[[.v(options$wlsWeights)]] <= 0)) 
@@ -290,15 +316,17 @@ Ancova <- function(jaspResults, dataset = NULL, options) {
   
   model <- .anovaModel(dataset, options)
 
-  if (.extractErrorMessage(model$modelError) == "singular fit encountered") {
-    anovaContainer$setError(gettext("Singular fit encountered; one or more predictor variables are a linear combination of other predictor variables"))
-    return()
-  } else if (.extractErrorMessage(model$modelError) == "residual sum of squares is 0 (within rounding error)") {
-    anovaContainer$setError(gettext("Residual sum of squares is 0; this might be due to extremely low variance of your dependent variable"))
-    return()
-  } else if (isTryError(model$modelError)) {
-    anovaContainer$setError(gettextf("An error occurred while computing the ANOVA: %s", .extractErrorMessage(model$modelError)))
-    return()
+  if (isTryError(model$modelError)) {
+    if (.extractErrorMessage(model$modelError) == "singular fit encountered") {
+      anovaContainer$setError(gettext("Singular fit encountered; one or more predictor variables are a linear combination of other predictor variables"))
+      return()
+    } else if (.extractErrorMessage(model$modelError) == "residual sum of squares is 0 (within rounding error)") {
+      anovaContainer$setError(gettext("Residual sum of squares is 0; this might be due to extremely low variance of your dependent variable"))
+      return()
+    } else {
+      anovaContainer$setError(gettextf("An error occurred while computing the ANOVA: %s", .extractErrorMessage(model$modelError)))
+      return()
+    }
   }
   
   # Save model to state


### PR DESCRIPTION
The changes to `if (isTryError(model$error))` are a remnant from https://github.com/jasp-stats/jasp-desktop/pull/4206/files?file-filters%5B%5D=.svg that apparently never got copied into this repo.

At one point we probably have to double-check if all code was copied to this repo...