### PR TITLE
Remove spurious commas from post-hoc table.

### DIFF
--- a/R/ancova.R
+++ b/R/ancova.R
@@ -25,7 +25,7 @@ Ancova <- function(jaspResults, dataset = NULL, options) {
 
   ready <- options$dependent != "" && length(options$fixedFactors) > 0 && nFactorModelTerms > 0
   options(contrasts = c("contr.sum","contr.poly"))
-  
+
   # Set corrections to FALSE when performing ANCOVA
   if (is.null(options$homogeneityBrown)) {
     options$homogeneityNone <- TRUE
@@ -34,14 +34,14 @@ Ancova <- function(jaspResults, dataset = NULL, options) {
   }
 
   if (is.null(dataset)) {
-    dataset <- .readDataSetToEnd(columns.as.numeric = numericVariables, 
-                                 columns.as.factor = factorVariables, 
+    dataset <- .readDataSetToEnd(columns.as.numeric = numericVariables,
+                                 columns.as.factor = factorVariables,
                                  exclude.na.listwise = c(numericVariables, factorVariables))
     dataset <- droplevels(dataset)
-  } 
-  
+  }
+
   anovaContainer <- .getAnovaContainer(jaspResults)
-  
+
   .anovaCheckErrors(dataset, options, ready)
 
   .anovaModelContainer(anovaContainer, dataset, options, ready)
@@ -49,19 +49,19 @@ Ancova <- function(jaspResults, dataset = NULL, options) {
   .anovaTable(anovaContainer, options, ready)
 
   .anovaAssumptionsContainer(anovaContainer, dataset, options, ready)
-  
+
   .anovaContrastsTable(anovaContainer, dataset, options, ready)
-  
+
   .anovaPostHocTableCollection(anovaContainer, dataset, options, ready)
-  
+
   .anovaMarginalMeans(anovaContainer, dataset, options, ready)
 
   .anovaSimpleEffects(anovaContainer, dataset, options, ready)
-  
+
   .anovaKruskal(anovaContainer, dataset, options, ready)
-  
+
   .BANOVAdescriptives(anovaContainer, dataset, options, list(noVariables=FALSE), "ANCOVA", ready)
-  
+
   return()
 }
 
@@ -78,16 +78,16 @@ Ancova <- function(jaspResults, dataset = NULL, options) {
 }
 
 .anovaContrastCases <- function(column, contrastType) {
-  
+
   levels <- levels(column)
   nLevels <- length(levels)
-  
+
   cases <- list()
-  
+
   if (nLevels == 1) {
-    
+
     cases[[1]] <- "."
-    
+
   } else {
     switch(contrastType,
       deviation = {
@@ -133,12 +133,12 @@ Ancova <- function(jaspResults, dataset = NULL, options) {
       }
     )
   }
-  
+
   cases
 }
 
 .anovaCheckErrors <- function(dataset, options, ready) {
-  if (!ready) 
+  if (!ready)
     return()
 
   modelTerms <- unlist(options$modelTerms, recursive = FALSE)
@@ -196,24 +196,24 @@ Ancova <- function(jaspResults, dataset = NULL, options) {
 
   }
 
-  .hasErrors(dataset = dataset, 
+  .hasErrors(dataset = dataset,
              custom = function() {
-               if (any(dataset[[.v(options$wlsWeights)]] <= 0)) 
+               if (any(dataset[[.v(options$wlsWeights)]] <= 0))
                  return(gettext("The WLS weights contain negative and/or zero values.<br><br>(only positive WLS weights allowed)."))
              },
              exitAnalysisIfErrors = TRUE)
 }
 
 .reorderModelTerms <- function(options) {
-  
+
   if(length(options$modelTerms) > 0) {
-    
+
     fixedFactors <- list()
     covariates <- list()
-    
+
     k <- 1
     l <- 1
-    
+
     for(i in 1:length(options$modelTerms)) {
       if (sum(unlist(options$modelTerms[[i]]$components) %in% options$covariates) > 0) {
         covariates[[k]] <- options$modelTerms[[i]]
@@ -223,7 +223,7 @@ Ancova <- function(jaspResults, dataset = NULL, options) {
         l <- l + 1
       }
     }
-    
+
     if(length(covariates) > length(options$covariates)) {
       modelTerms <- options$modelTerms
       interactions <- TRUE
@@ -232,54 +232,54 @@ Ancova <- function(jaspResults, dataset = NULL, options) {
       modelTerms <- modelTerms[match(modelTerms, options$modelTerms)]
       interactions <- FALSE
     }
-    
+
   } else {
-    
+
     modelTerms <- list()
     interactions <- FALSE
   }
-  
+
   list(modelTerms = modelTerms, interactions = interactions)
 }
 
 .modelFormula <- function(modelTerms, options) {
-  
+
   dependent.normal <- options$dependent
   dependent.base64 <- .v(options$dependent)
-  
+
   terms.base64 <- c()
   terms.normal <- c()
-  
+
   for (term in modelTerms) {
-    
+
     components <- unlist(term$components)
     term.base64 <- paste(.v(components), collapse=":", sep="")
     term.normal <- paste(components, collapse=" \u273B ", sep="")
-    
+
     terms.base64 <- c(terms.base64, term.base64)
     terms.normal <- c(terms.normal, term.normal)
   }
-  
+
   model.def <- paste(dependent.base64, "~", paste(terms.base64, collapse="+"))
-  
+
   list(model.def = model.def, terms.base64 = terms.base64, terms.normal = terms.normal)
 }
 
 .anovaModel <- function(dataset, options) {
-  
+
   afex::afex_options(
-    check_contrasts = TRUE, correction_aov = "GG", 
-    emmeans_model = "univariate", es_aov = "ges", factorize = TRUE, 
-    lmer_function = "lmerTest", method_mixed = "KR", return_aov = "afex_aov", 
+    check_contrasts = TRUE, correction_aov = "GG",
+    emmeans_model = "univariate", es_aov = "ges", factorize = TRUE,
+    lmer_function = "lmerTest", method_mixed = "KR", return_aov = "afex_aov",
     set_data_arg = FALSE, sig_symbols = c(" +", " *", " **", " ***"), type = 3
   )
-  
+
   reorderModelTerms <-  .reorderModelTerms(options)
   modelTerms <- reorderModelTerms$modelTerms
-  
+
   modelDef <- .modelFormula(modelTerms, options)
   model.formula <- as.formula(modelDef$model.def)
-  
+
   WLS <- NULL
   if ( ! is.null(options$wlsWeights))
     WLS <- dataset[[ .v(options$wlsWeights) ]]
@@ -294,26 +294,26 @@ Ancova <- function(jaspResults, dataset = NULL, options) {
     afexData <- dataset
     afexData[["ID"]] <- as.factor(1:nrow(dataset))
     afexModel <- try(afex::aov_car(afexFormula, data=afexData, type= 3, factorize = FALSE, include_aov = TRUE))
-    
-    if (isTryError(afexModel)) 
+
+    if (isTryError(afexModel))
       modelError <- afexModel
-    
+
   } else {
     afexModel <- NULL
   }
-  
-  
+
+
   return(list(model = model, modelError = modelError, afexModel = afexModel))
 }
 
 .anovaModelContainer <- function(anovaContainer, dataset, options, ready) {
-  if (!ready) 
+  if (!ready)
     return()
 
   # Take results from state if possible
   if (!is.null(anovaContainer[["model"]]))
     return()
-  
+
   model <- .anovaModel(dataset, options)
 
   if (isTryError(model$modelError)) {
@@ -328,7 +328,7 @@ Ancova <- function(jaspResults, dataset = NULL, options) {
       return()
     }
   }
-  
+
   # Save model to state
   anovaContainer[["model"]] <- createJaspState(object = model$model)
   anovaContainer[["afexModel"]] <- createJaspState(object = model$afexModel)
@@ -336,36 +336,36 @@ Ancova <- function(jaspResults, dataset = NULL, options) {
 
 .anovaResult <- function(anovaContainer, options) {
 
-  if (anovaContainer$getError()) 
+  if (anovaContainer$getError())
     return()
-  
+
   model <- anovaContainer[["model"]]$object
-  
+
   reorderModelTerms <-  .reorderModelTerms(options)
   modelTerms <- reorderModelTerms$modelTerms
-  
+
   modelDef <- .modelFormula(modelTerms, options)
   termsNormal <- modelDef$terms.normal
   termsBase64 <- modelDef$terms.base64
-  
+
   ## Computation
   if (options$sumOfSquares == "type1") {
-    
+
     result <- base::tryCatch(stats::anova(model),error=function(e) e, warning=function(w) w)
-    
+
     if (!is.null(result$message)) {
       anovaContainer$setError(result$message)
       return()
     }
-    
+
     result['SSt'] <- sum(result[,"Sum Sq"], na.rm = TRUE)
-    
+
   } else if (options$sumOfSquares == "type2") {
-    
+
     result <- car::Anova(model, type=2)
     result['Mean Sq'] <- result[['Sum Sq']] / result[['Df']]
     result['SSt'] <- sum(result[['Sum Sq']], na.rm = TRUE)
-    
+
   } else if (options$sumOfSquares == "type3") {
 
     modelTerms <- unlist(options$modelTerms, recursive = FALSE)
@@ -380,42 +380,42 @@ Ancova <- function(jaspResults, dataset = NULL, options) {
     result <- result[-1, ]
     result['Mean Sq'] <- result[['Sum Sq']] / result[['Df']]
     result['SSt'] <- sum(result["Sum Sq"], na.rm = TRUE)
-    
+
   }
-  
+
   # Make sure that the order of the result is same order as reordered modelterms
   result <- result[.mapAnovaTermsToTerms(c(termsBase64, "Residuals"), rownames(result) ), ]
   result[['cases']] <- c(termsNormal, "Residuals")
   result <- as.data.frame(result)
   result[['.isNewGroup']] <- c(TRUE, rep(FALSE, nrow(result)-2), TRUE)
   if (length(options$covariates) > 0)
-    result[.v(options$covariates), ][[".isNewGroup"]] <- TRUE 
-  
+    result[.v(options$covariates), ][[".isNewGroup"]] <- TRUE
+
   result[1, 'correction'] <- "None"
 
   if (options$effectSizeEstimates) {
-    
+
       SSt <- result['SSt']
       SSr <- result["Residuals", "Sum Sq"]
       MSr <- SSr/result["Residuals", "Df"]
-      
+
       eta <- result[['Sum Sq']] / result[['SSt']]
       etaPart <- result[['Sum Sq']] / (result[['Sum Sq']] + SSr)
       omega <- (result[['Sum Sq']] - (result[['Df']] * MSr)) / (SSt + MSr)
       omega <- sapply(omega[,1], function(x) max(x, 0))
-      
+
       result[, c("eta", "etaPart", "omega")] <- cbind(eta, etaPart, omega)
       result["Residuals", c("eta", "etaPart", "omega")] <- NA
-      
+
   }
-    
+
   if (options$VovkSellkeMPR) {
     result[["VovkSellkeMPR"]] <-  ifelse(result[['Pr(>F)']] != "", VovkSellkeMPR(na.omit(result[['Pr(>F)']])), "")
   }
-  
-  if ((options$homogeneityBrown || options$homogeneityWelch) && length(options$modelTerms) > 1) 
+
+  if ((options$homogeneityBrown || options$homogeneityWelch) && length(options$modelTerms) > 1)
     return()
-  
+
   anovaResult <- list()
   if (options$homogeneityNone) {
     anovaResult[["result"]] <- result
@@ -426,21 +426,21 @@ Ancova <- function(jaspResults, dataset = NULL, options) {
     tempResult <- onewaytests::bf.test(as.formula(modelDef$model.def), model$model)
     brownResult <- result
     brownResult[[1, 'correction']] <- "Brown-Forsythe"
-    
-    if (options$homogeneityNone) 
+
+    if (options$homogeneityNone)
       brownResult[['.isNewGroup']] <- c(TRUE, rep(FALSE, nrow(result)-1))
-    
+
     brownResult[[termsBase64, 'Df']] <- tempResult[['parameter']][[1]]
     brownResult[[termsBase64, 'Pr(>F)']] <- tempResult[['p.value']]
     brownResult[[termsBase64, 'F value']] <- tempResult[['statistic']]
     brownResult[['Residuals', 'Df']] <- tempResult[['parameter']][[2]]
     brownResult[['Mean Sq']] <- brownResult[['Sum Sq']] / brownResult[['Df']]
-    
+
     if (options$VovkSellkeMPR) {
-      brownResult[['VovkSellkeMPR']] <-  ifelse(brownResult[['Pr(>F)']] != "", 
+      brownResult[['VovkSellkeMPR']] <-  ifelse(brownResult[['Pr(>F)']] != "",
                                                 VovkSellkeMPR(na.omit(brownResult[['Pr(>F)']])), "")
     }
-    
+
     anovaResult[['brownResult']] <- brownResult
   }
 
@@ -449,8 +449,8 @@ Ancova <- function(jaspResults, dataset = NULL, options) {
     tempResult <- stats::oneway.test(as.formula(modelDef$model.def), model$model, var.equal = FALSE)
     welchResult <- result
     welchResult[[1, 'correction']] <- "Welch"
-    
-    if (options$homogeneityNone || options$homogeneityBrown) 
+
+    if (options$homogeneityNone || options$homogeneityBrown)
       welchResult[['.isNewGroup']] <- c(TRUE, rep(FALSE, nrow(result)-1))
 
     welchResult[[termsBase64, 'Df']] <- tempResult[['parameter']][[1]]
@@ -460,16 +460,16 @@ Ancova <- function(jaspResults, dataset = NULL, options) {
     welchResult[['Mean Sq']] <- welchResult[['Sum Sq']] / welchResult[['Df']]
 
     if (options$VovkSellkeMPR) {
-      welchResult[["VovkSellkeMPR"]] <-  ifelse(!is.na(welchResult[['Pr(>F)']]), 
+      welchResult[["VovkSellkeMPR"]] <-  ifelse(!is.na(welchResult[['Pr(>F)']]),
                                                 VovkSellkeMPR(na.omit(welchResult[["Pr(>F)"]])), NA)
     }
-    
+
     anovaResult[['welchResult']] <- welchResult
-  } 
+  }
 
   # Save model to state
   anovaContainer[["anovaResult"]] <- createJaspState(object = anovaResult)
-  anovaContainer[["anovaResult"]]$dependOn(c("sumOfSquares", "homogeneityBrown", "homogeneityWelch", 
+  anovaContainer[["anovaResult"]]$dependOn(c("sumOfSquares", "homogeneityBrown", "homogeneityWelch",
                                              "homogeneityNone", "effectSizeEstimates", "effectSizeEtaSquared",
                                               "effectSizePartialEtaSquared", "effectSizeOmegaSquared"))
 }
@@ -477,14 +477,14 @@ Ancova <- function(jaspResults, dataset = NULL, options) {
 .anovaTable <- function(anovaContainer, options, ready) {
   if (!is.null(anovaContainer[["anovaTable"]]))
     return()
-  
+
   title <- ifelse(is.null(options$covariates), gettext("ANOVA"), gettext("ANCOVA"))
-  anovaTable <- createJaspTable(title = title, position = 1, 
-                           dependencies = c("homogeneityWelch", "homogeneityBrown", "homogeneityNone", 
-                                            "VovkSellkeMPR", "effectSizeEstimates", "effectSizeEtaSquared", 
+  anovaTable <- createJaspTable(title = title, position = 1,
+                           dependencies = c("homogeneityWelch", "homogeneityBrown", "homogeneityNone",
+                                            "VovkSellkeMPR", "effectSizeEstimates", "effectSizeEtaSquared",
                                             "effectSizePartialEtaSquared", "effectSizeOmegaSquared"))
-  
-  corrections <- c("None", "Brown-Forsythe", "Welch")[c(options$homogeneityNone, 
+
+  corrections <- c("None", "Brown-Forsythe", "Welch")[c(options$homogeneityNone,
                                                         options$homogeneityBrown,
                                                         options$homogeneityWelch)]
 
@@ -492,54 +492,54 @@ Ancova <- function(jaspResults, dataset = NULL, options) {
   if ((length(corrections) > 1 || any(!"None" %in% corrections)) && is.null(options$covariates)) {
     anovaTable$addColumnInfo(title = gettext("Homogeneity Correction"), name = "correction", type = "string")
     dfType <- "number"
-  } 
-  
+  }
+
   anovaTable$addColumnInfo(title = gettext("Cases"),          name = "cases",   type = "string" )
   anovaTable$addColumnInfo(title = gettext("Sum of Squares"), name = "Sum Sq",  type = "number")
   anovaTable$addColumnInfo(title = gettext("df"),             name = "Df",      type = dfType)
   anovaTable$addColumnInfo(title = gettext("Mean Square"),    name = "Mean Sq", type = "number")
   anovaTable$addColumnInfo(title = gettext("F"),              name = "F value", type = "number")
   anovaTable$addColumnInfo(title = gettext("p"),              name = "Pr(>F)",  type = "pvalue")
-  
+
   if (options$VovkSellkeMPR) {
     anovaTable$addColumnInfo(title = gettextf("VS-MPR%s", "\u002A"), name = "VovkSellkeMPR", type = "number")
     anovaTable$addFootnote(message = .messages("footnote", "VovkSellkeMPR"), symbol = "\u002A")
   }
-  
+
   if (options$effectSizeEstimates) {
-    
+
     if (options$effectSizeEtaSquared) {
       anovaTable$addColumnInfo(title = "\u03B7\u00B2", name = "eta", type = "number")
     }
-    
+
     if (options$effectSizePartialEtaSquared) {
       anovaTable$addColumnInfo(title = "\u03B7\u00B2\u209A", name = "etaPart", type = "number")
     }
-    
+
     if (options$effectSizeOmegaSquared) {
       anovaTable$addColumnInfo(title = "\u03C9\u00B2", name = "omega", type = "number")
     }
-    
+
   }
 
   anovaTable$showSpecifiedColumnsOnly <- TRUE
-  
+
   # set the type footnote already
   typeFootnote <- switch(options$sumOfSquares,
                          type1 = gettext("Type I Sum of Squares"),
                          type2 = gettext("Type II Sum of Squares"),
                          type3 = gettext("Type III Sum of Squares"))
   anovaTable$addFootnote(typeFootnote)
-  
+
   anovaContainer[["anovaTable"]] <- anovaTable
-  
+
   if (!ready || anovaContainer$getError())
     return()
-  
+
   anovaTable$title <- paste0(title, " - ", options$dependent)
 
   anovaTable$setExpectedSize(rows = length(options$modelTerms) * length(corrections))
-  
+
   # here we ask for the model to be computed
   .anovaResult(anovaContainer, options)
 
@@ -547,7 +547,7 @@ Ancova <- function(jaspResults, dataset = NULL, options) {
     anovaTable$setError(gettext("The Brown-Forsythe and Welch corrections are only available for one-way ANOVA"))
     return()
   }
-    
+
   if (anovaContainer$getError())
     return()
 
@@ -560,18 +560,18 @@ Ancova <- function(jaspResults, dataset = NULL, options) {
 .anovaContrastsTable <- function(anovaContainer, dataset, options, ready) {
   if (!is.null(anovaContainer[["contrastContainer"]]) || all(grepl("none", options$contrasts)))
     return()
-  
+
   contrastContainer <- createJaspContainer(title = gettext("Contrast Tables"))
-  contrastContainer$dependOn(c("contrasts", "confidenceIntervalIntervalContrast", 
+  contrastContainer$dependOn(c("contrasts", "confidenceIntervalIntervalContrast",
                                "confidenceIntervalsContrast", "customContrasts"))
-  
+
   for (contrast in options$contrasts) {
-    
+
     if (contrast$contrast != "none") {
       contrastType <- unlist(strsplit(contrast$contrast, ""))
       contrastType[1] <- toupper(contrastType[1])
       contrastType <- paste0(contrastType, collapse = "")
-      
+
       if (length(contrast$variable) == 1) {
         contrastVariable <- contrast$variable
       } else {
@@ -581,25 +581,25 @@ Ancova <- function(jaspResults, dataset = NULL, options) {
       myTitle <- gettextf("%1$s Contrast - %2$s", contrastType,  contrastVariable)
       contrastContainerName <- paste0(contrast$contrast, "Contrast_",  paste(contrast$variable, collapse = ":"))
       contrastContainer[[contrastContainerName]] <- createJaspContainer()
-      contrastContainer[[contrastContainerName]][["contrastTable"]] <- .createContrastTableAnova(myTitle, 
+      contrastContainer[[contrastContainerName]][["contrastTable"]] <- .createContrastTableAnova(myTitle,
                                                                                                  options)
     }
-      
+
   }
-  
+
   anovaContainer[["contrastContainer"]] <- contrastContainer
-  
-  if (!ready || anovaContainer$getError()) 
+
+  if (!ready || anovaContainer$getError())
     return()
-  
+
   afexModel <- anovaContainer[["afexModel"]]$object
-  
+
   ## Computation
   model <- anovaContainer[["model"]]$object
   contrastSummary <- summary.lm(model)[["coefficients"]]
-  
+
   for (contrast in options$contrasts) {
-    
+
     contrastContainerName <- paste0(contrast$contrast, "Contrast_",  paste(contrast$variable, collapse = ":"))
 
     if (contrast$contrast != "none") {
@@ -608,13 +608,13 @@ Ancova <- function(jaspResults, dataset = NULL, options) {
       v <- .v(variable)
 
       if (contrast$contrast == "custom") {
-        customContrastSetup <- options$customContrasts[[which(sapply(options$customContrasts, 
+        customContrastSetup <- options$customContrasts[[which(sapply(options$customContrasts,
                                                                      function(x)  all(x$value %in% contrast$variable) &&
                                                                        length(contrast$variable) == length(x$value)))]]
       } else {
         customContrastSetup <- NULL
       }
-    
+
       if (length(v) == 1) {
         column <- dataset[[ v ]]
       } else {
@@ -622,7 +622,7 @@ Ancova <- function(jaspResults, dataset = NULL, options) {
       }
 
       contrastMatrix    <- .createContrastAnova(column, contrast$contrast, customContrastSetup)
-      
+
       if (contrast$contrast != "custom") {
         cases <- .anovaContrastCases(column, contrast$contrast)
         contrCoef         <- lapply(as.data.frame(contrastMatrix), as.vector)
@@ -633,9 +633,9 @@ Ancova <- function(jaspResults, dataset = NULL, options) {
 
       referenceGrid <- emmeans::emmeans(afexModel, v, model = "multivariate")
       contrastResult    <- try(emmeans::contrast(referenceGrid, contrCoef), silent = TRUE)
-      # is input the same as used by emmeans? 
+      # is input the same as used by emmeans?
       # all(as.matrix( coef(contrastResult)[, -(1:length(v)) ]) == t(contrastMatrix))
-      
+
       if (contrast$contrast == "custom") {
         if (isTryError(contrastResult)) {
           if (grepl(contrastResult[1], pattern = "Nonconforming number")) {
@@ -647,12 +647,12 @@ Ancova <- function(jaspResults, dataset = NULL, options) {
         } else if (any(apply(contrastMatrix, 1, function(x) all(x == 0) ))) {
           contrastContainer[[contrastContainerName]]$setError(gettext("Please specify non-zero contrast weights."))
           return()
-        } 
+        }
       }
-      
+
       contrCoef <- coef(contrastResult)
       colnames(contrCoef) <- c(contrast$variable, paste("Comparison", 1: (ncol(contrCoef) - length(contrast$variable))))
-      
+
       contrastResult <- cbind(contrastResult, confint(contrastResult, level = options$confidenceIntervalIntervalContrast)[,5:6])
       contrastResult[["Comparison"]] <- .unv(contrastResult[["contrast"]])
       contrastResult[[".isNewGroup"]] <- c(TRUE, rep(FALSE, nrow(contrastResult)-1))
@@ -660,164 +660,164 @@ Ancova <- function(jaspResults, dataset = NULL, options) {
       if (contrast$contrast == "custom" | length(contrast$variable) > 1) {
         contrastResult$Comparison <- 1:nrow(contrastResult)
         weightType <-  if (all(apply(contrastMatrix, 2, function(x) x %% 1 == 0))) "integer" else "number"
-        contrastContainer[[contrastContainerName]][["customCoefTable"]] <- .createCoefficientsTableAnova(contrast, 
-                                                                                                         contrCoef, 
+        contrastContainer[[contrastContainerName]][["customCoefTable"]] <- .createCoefficientsTableAnova(contrast,
+                                                                                                         contrCoef,
                                                                                                          weightType)
       }
 
       contrastContainer[[contrastContainerName]][["contrastTable"]]$setData(contrastResult)
-      
+
     }
-    
+
   }
-  
+
   return()
 }
 
 .createContrastAnova <- function (column, contrast.type, customContrast) {
-  
+
   levels <- levels(column)
   n.levels <- length(levels)
-  
+
   contr <- NULL
-  
+
   switch(contrast.type,
          none = {
-           
+
            options(contrasts = c("contr.sum","contr.poly"))
            contr <- NULL
-           
+
          },
          deviation = {
-           
+
            contr <- matrix(0,nrow = n.levels, ncol = n.levels - 1)
            for (i in 2:n.levels) {
              contr[,(i-1)] <-  -1 / n.levels
              contr[i,(i-1)] <- (n.levels - 1) / n.levels
            }
-           
+
          },
          simple = {
-           
+
            contr <- matrix(0,nrow = n.levels, ncol = n.levels - 1)
            for (i in 1:n.levels-1) {
              contr[c(1,i+1),i]<- c(1,-1) * -1
            }
-           
+
          },
          Helmert = {
-           
+
            contr <- contr.helmert(levels)
            contr <- apply(contr, 2, function(x){ x/max(abs(x))})
            contr <- matrix(rev(contr), ncol = ncol(contr), nrow = nrow(contr))
-           
+
          },
          repeated = {
-           
+
            contr <- matrix(0,nrow = n.levels, ncol = n.levels - 1)
-           
+
            for (i in 1:(n.levels-1)) {
              contr[i,i] <- 1
              contr[i+1,i] <- -1
            }
-           
+
          },
          difference = {
-           
+
            contr <- contr.helmert(levels)
            contr <- apply(contr, 2, function(x){ x/max(abs(x))})
-           
+
          },
          polynomial = {
-           
+
            contr <- contr.poly(levels)
-           
-         }, 
+
+         },
          custom = {
-           
+
            isContrast <- sapply(customContrast[["values"]], function(x) x$isContrast)
            customContrMat <- as.matrix(sapply(customContrast[["values"]][isContrast], function(x) as.numeric(x$values)))
            contr <- t(customContrMat)
 
          }
   )
-  
+
   if (! is.null(contr)) {
     dimnames(contr) <- list(NULL, 1:dim(contr)[2])
   }
-  
+
   contr
 }
 
 
 .createContrastTableAnova <- function(myTitle, options, dfType = "integer") {
-  
+
   contrastTable <- createJaspTable(title = myTitle)
   contrastTable$addColumnInfo(name = "Comparison", type = "string")
   contrastTable$addColumnInfo(name = "estimate", title=gettext("Estimate"), type = "number")
-  
+
   if (options$confidenceIntervalsContrast) {
-    
+
     thisOverTitle <- gettextf("%s%% CI for Mean Difference", options$confidenceIntervalIntervalContrast * 100)
     contrastTable$addColumnInfo(name="lower.CL", type = "number", title = gettext("Lower"), overtitle = thisOverTitle)
     contrastTable$addColumnInfo(name="upper.CL", type = "number", title = gettext("Upper"), overtitle = thisOverTitle)
-    
-  } 
-  
+
+  }
+
   contrastTable$addColumnInfo(name = "SE", title=gettext("SE"), type = "number")
   contrastTable$addColumnInfo(name = "df",      title = gettext("df"), type = dfType)
   contrastTable$addColumnInfo(name = "t.ratio", title = gettext("t"),  type = "number")
   contrastTable$addColumnInfo(name = "p.value", title = gettext("p"),  type = "pvalue")
-  
+
   contrastTable$showSpecifiedColumnsOnly <- TRUE
-  
+
   return(contrastTable)
 }
 
 .createCoefficientsTableAnova <- function(contrast, contrCoef, weightType = "number") {
-  
+
   contrastType <- unlist(strsplit(contrast$contrast, ""))
   contrastType[1] <- toupper(contrastType[1])
   contrastType <- paste0(contrastType, collapse = "")
-  
-  myTitle <-  gettextf("%1$s Contrast Coefficients - %2$s", 
-                       contrastType,  
+
+  myTitle <-  gettextf("%1$s Contrast Coefficients - %2$s",
+                       contrastType,
                        paste(contrast$variable, collapse = " \u273B "))
-  
+
   coefTable <- createJaspTable(title = myTitle)
-  
-  for (thisVar in names(contrCoef)[1:length(contrast$variable)]) 
+
+  for (thisVar in names(contrCoef)[1:length(contrast$variable)])
     coefTable$addColumnInfo(name = thisVar, type = "string", combine = TRUE)
-  
+
   for (thisComp in paste("Comparison", 1: (ncol(contrCoef) - length(contrast$variable))))
     coefTable$addColumnInfo(name = thisComp, type = weightType)
-  
+
   coefTable$setData(contrCoef)
-  
+
   return(coefTable)
 }
 
 .postHocContrasts <- function(variableLevels, dataset, options) {
-  
+
   contrasts <- NULL
   nLevels <- length(variableLevels)
-  
+
   for (i in 1:(nLevels - 1)) {
-    
+
     for (j in (i + 1):nLevels) {
-      
+
       name <- paste(variableLevels[[i]], "-", variableLevels[[j]], sep = " ")
       contrast <- rep(0, nLevels)
       contrast[i] <- -1
       contrast[j] <- 1
-      
+
       arg <- list(contrasts, contrast)
       names(arg)[2] <- name
       contrasts <- do.call(rbind, arg)
-      
+
     }
   }
-  
+
   return(contrasts)
 }
 
@@ -826,90 +826,90 @@ Ancova <- function(jaspResults, dataset = NULL, options) {
     return()
 
   if (is.null(anovaContainer[["postHocContainer"]])) {
-    
+
     postHocContainer <- createJaspContainer(title = gettext("Post Hoc Tests"))
     postHocContainer$dependOn(c("postHocTestsVariables"))
     anovaContainer[["postHocContainer"]] <- postHocContainer
-    
+
   } else {
-    
+
     postHocContainer <- anovaContainer[["postHocContainer"]]
-    
+
   }
 
   if (options$postHocTestsTypeStandard)
     .anovaPostHocTable(postHocContainer, dataset, options,  anovaContainer[["model"]]$object)
 
-  if (options$postHocTestsTypeGames) 
+  if (options$postHocTestsTypeGames)
     gamesPostHoc <- .anovaGamesTable(postHocContainer, dataset, options,  anovaContainer[["model"]]$object)
-  
-  if (options$postHocTestsTypeDunnett) 
+
+  if (options$postHocTestsTypeDunnett)
     dunnettPostHoc <- .anovaDunnettTable(postHocContainer, dataset, options,  anovaContainer[["model"]]$object)
-  
-  if (options$postHocTestsTypeDunn) 
+
+  if (options$postHocTestsTypeDunn)
     dunnPostHoc <- .anovaDunnTable(postHocContainer, dataset, options,  anovaContainer[["model"]]$object)
-  
+
   return()
 }
 
 .anovaPostHocTable <- function(postHocContainer, dataset, options, model) {
   if (!is.null(postHocContainer[["postHocStandardContainer"]]))
     return()
-  
+
   postHocStandardContainer <- createJaspContainer(title = gettext("Standard"))
-  postHocStandardContainer$dependOn(c("postHocTestsVariables", "postHocTestEffectSize", "postHocTestsTypeStandard", 
-                                      "postHocTestsBonferroni", "postHocTestsHolm", "postHocTestsScheffe", 
-                                      "postHocTestsTukey", "postHocTestsSidak", "postHocFlagSignificant", 
-                                      "postHocTestsBootstrapping", "postHocTestsBootstrappingReplicates", 
+  postHocStandardContainer$dependOn(c("postHocTestsVariables", "postHocTestEffectSize", "postHocTestsTypeStandard",
+                                      "postHocTestsBonferroni", "postHocTestsHolm", "postHocTestsScheffe",
+                                      "postHocTestsTukey", "postHocTestsSidak", "postHocFlagSignificant",
+                                      "postHocTestsBootstrapping", "postHocTestsBootstrappingReplicates",
                                       "confidenceIntervalsPostHoc", "confidenceIntervalIntervalPostHoc"))
-  
+
   postHocContainer[["postHocStandardContainer"]] <- postHocStandardContainer
-  
+
   postHocVariables <- unlist(options$postHocTestsVariables, recursive = FALSE)
   postHocVariablesListV <- unname(lapply(postHocVariables, .v))
-  
+
   for (postHocVarIndex in 1:length(postHocVariables)) {
-    
+
     thisVarName <- paste(postHocVariables[[postHocVarIndex]], collapse = " \u273B ")
     interactionTerm <- length(postHocVariables[[postHocVarIndex]]) > 1
-    
+
     postHocStandardContainer[[thisVarName]] <- .createPostHocStandardTable(thisVarName, interactionTerm, options,
                                                                            options$postHocTestsBootstrapping)
   }
 
   for (postHocVarIndex in 1:length(postHocVariables)) {
-    
+
     thisVarName <- paste(postHocVariables[[postHocVarIndex]], collapse = " \u273B ")
     interactionTerm <- length(postHocVariables[[postHocVarIndex]]) > 1
     postHocInterval  <- options$confidenceIntervalIntervalPostHoc
 
     postHocRef <- emmeans::lsmeans(model, postHocVariablesListV)
-    
+
     postHocCorrections <- c("tukey", "scheffe", "bonferroni", "holm", "sidak")
 
     ## Computation
     resultPostHoc <- lapply(postHocCorrections, function(x)
-      summary(emmeans::contrast(postHocRef[[postHocVarIndex]], method = "pairwise"), 
+      summary(emmeans::contrast(postHocRef[[postHocVarIndex]], method = "pairwise"),
               adjust = x, infer = c(TRUE, TRUE), level = options$confidenceIntervalIntervalPostHoc))
 
     allContrasts <- strsplit(as.character(resultPostHoc[[1]]$contrast), split = " - ")
-    
+
     if (nrow(resultPostHoc[[1]]) > 1)
-      postHocStandardContainer[[thisVarName]]$addFootnote(.getCorrectionFootnoteAnova(resultPostHoc[[1]], 
+      postHocStandardContainer[[thisVarName]]$addFootnote(.getCorrectionFootnoteAnova(resultPostHoc[[1]],
                                                                                       options$confidenceIntervalsPostHoc))
-    
+
     avFootnote <- attr(resultPostHoc[[1]], "mesg")[grep(attr(resultPostHoc[[1]], "mesg"), pattern = "Results are averaged")]
     if (length(avFootnote) != 0) {
-      avTerms <- .unv(strsplit(gsub(avFootnote, pattern = "Results are averaged over the levels of: ", replacement = ""), 
+      avTerms <- .unv(strsplit(gsub(avFootnote, pattern = "Results are averaged over the levels of: ", replacement = ""),
                                ", ")[[1]])
       postHocStandardContainer[[thisVarName]]$addFootnote(gettextf("Results are averaged over the levels of: %s", paste(avTerms, collapse = ", ")))
     }
-    
+
     # Calculate effect sizes
     if (options$postHocTestEffectSize && nrow(dataset) > 0 && !interactionTerm) {
-      
+
       den <- numeric(length(allContrasts))
-      
+
       for(i in 1:length(allContrasts)) {
         x <- dataset[(dataset[.v(thisVarName)] == allContrasts[[i]][1]), .v(options$dependent)]
         y <- dataset[(dataset[.v(thisVarName)] == allContrasts[[i]][2]), .v(options$dependent)]
@@ -917,7 +917,7 @@ Ancova <- function(jaspResults, dataset = NULL, options) {
         n2 <- length(y)
         den[i] <- sqrt(((n1 - 1) * var(x) + (n2 - 1) * var(y)) / (n1 + n2 - 2))
       }
-      resultPostHoc[[1]][["cohenD"]] <- resultPostHoc[[1]][["estimate"]] / den 
+      resultPostHoc[[1]][["cohenD"]] <- resultPostHoc[[1]][["estimate"]] / den
       postHocStandardContainer[[thisVarName]]$addFootnote(gettext("Cohen's d does not correct for multiple comparisons."))
     }
 
@@ -931,126 +931,126 @@ Ancova <- function(jaspResults, dataset = NULL, options) {
                                                                            collapse = ", "))
 
     if (options$postHocTestsBootstrapping) {
-      
+
       postHocStandardContainer[[thisVarName]]$addFootnote(message = gettextf("Bootstrapping based on %s successful replicates.", as.character(options[['postHocTestsBootstrappingReplicates']])))
       postHocStandardContainer[[thisVarName]]$addFootnote(message = gettext("Mean Difference estimate is based on the median of the bootstrap distribution."))
       postHocStandardContainer[[thisVarName]]$addFootnote(symbol = "\u2020", message = gettext("Bias corrected accelerated."))
-      
-      startProgressbar(options[["postHocTestsBootstrappingReplicates"]] * length(postHocVariables), 
+
+      startProgressbar(options[["postHocTestsBootstrappingReplicates"]] * length(postHocVariables),
                        label = gettext("Bootstrapping Post Hoc Test"))
-      
+
       ## Computation
-      bootstrapPostHoc <- try(boot::boot(data = dataset, statistic = .bootstrapPostHoc, 
+      bootstrapPostHoc <- try(boot::boot(data = dataset, statistic = .bootstrapPostHoc,
                                          R = options[["postHocTestsBootstrappingReplicates"]],
-                                         options = options, 
+                                         options = options,
                                          nComparisons = nrow(resultPostHoc),
                                          postHocVariablesListV = postHocVariablesListV,
                                          postHocVarIndex = postHocVarIndex),
                               silent = TRUE)
-      
+
       if (class(bootstrapPostHoc) == "try-error") {
         postHocStandardContainer[[thisVarName]]$setError(bootstrapPostHoc)
         next
       }
-      
+
       bootstrapSummary <- summary(bootstrapPostHoc)
-      
+
       ci.fails <- FALSE
       bootstrapPostHocConf <- t(sapply(1:nrow(bootstrapSummary), function(comparison){
         res <- try(boot::boot.ci(boot.out = bootstrapPostHoc, conf = options$confidenceIntervalIntervalPostHoc, type = "bca",
                                  index = comparison)[['bca']][1,4:5])
-        
+
         if(!inherits(res, "try-error")){
           return(res)
         } else {
           ci.fails <<- TRUE
           return(c(NA, NA))
-        } 
+        }
       }))
-      
+
       if (ci.fails)
         postHocStandardContainer[[thisVarName]]$addFootnote(message = gettext("Some confidence intervals could not be computed.\nPossibly too few bootstrap replicates."))
-      
+
       resultPostHoc[["lower.CL"]] <- bootstrapPostHocConf[,1]
       resultPostHoc[["upper.CL"]] <- bootstrapPostHocConf[,2]
-      
+
       resultPostHoc[["bias"]] <- bootstrapSummary[["bootBias"]]
       resultPostHoc[["SE"]] <- bootstrapSummary[["bootSE"]]
       resultPostHoc[["estimate"]] <- bootstrapSummary[["bootMed"]]
-      
+
     }
-    
+
     resultPostHoc[[".isNewGroup"]] <- c(TRUE, rep(FALSE, nrow(resultPostHoc)-1))
     postHocStandardContainer[[thisVarName]]$setData(resultPostHoc)
 
-    whichPvalues <- c(options$postHocTestsTukey, options$postHocTestsScheffe, options$postHocTestsBonferroni, 
+    whichPvalues <- c(options$postHocTestsTukey, options$postHocTestsScheffe, options$postHocTestsBonferroni,
                       options$postHocTestsHolm, options$postHocTestsSidak)
     allPvalues <- as.data.frame(allPvalues)
 
-    if (options$postHocFlagSignificant && length(postHocCorrections[whichPvalues]) > 0) 
-      .anovaAddSignificanceSigns(someTable = postHocStandardContainer[[thisVarName]], 
-                                 allPvalues = allPvalues, 
+    if (options$postHocFlagSignificant && length(postHocCorrections[whichPvalues]) > 0)
+      .anovaAddSignificanceSigns(someTable = postHocStandardContainer[[thisVarName]],
+                                 allPvalues = allPvalues,
                                  resultRowNames = rownames(resultPostHoc))
-    
+
   }
-  
-  
+
+
   return()
 }
 
 .anovaAddSignificanceSigns <- function(someTable, allPvalues, resultRowNames) {
-  
+
   threeStarSignif <- twoStarSignif <- oneStarSignif <- FALSE
-  
+
   for (thisP in colnames(allPvalues)) {
-    
+
     signifComparisonsThreeStars <- resultRowNames[allPvalues[, thisP] < 0.001]
     signifComparisonsTwoStars <- resultRowNames[allPvalues[, thisP] < 0.01 & allPvalues[, thisP] >= 0.001]
     signifComparisonsOneStar <- resultRowNames[allPvalues[, thisP] < 0.05 & allPvalues[, thisP] >= 0.01]
-    
+
     if (length(signifComparisonsThreeStars) > 0 && !any(allPvalues[, thisP] == ".")) {
       colNames <- rep(thisP, length(signifComparisonsThreeStars))
       someTable$addFootnote(colNames = colNames, rowNames = signifComparisonsThreeStars, symbol = "***")
       threeStarSignif <- TRUE
     }
-    
+
     if (length(signifComparisonsTwoStars) > 0 && !any(allPvalues[, thisP] == ".")) {
       colNames <- rep(thisP, length(signifComparisonsTwoStars))
       someTable$addFootnote(colNames = colNames, rowNames = signifComparisonsTwoStars, symbol = "**")
       twoStarSignif <- TRUE
     }
-    
+
     if (length(signifComparisonsOneStar) > 0 && !any(allPvalues[, thisP] == ".")) {
       colNames <- rep(thisP, length(signifComparisonsOneStar))
       someTable$addFootnote(colNames = colNames, rowNames = signifComparisonsOneStar, symbol = "*")
       oneStarSignif <- TRUE
     }
-    
+
   }
-  
+
   signifMessage <- c("* p < .05", "** p < .01", "*** p < .001")[c(oneStarSignif, twoStarSignif, threeStarSignif)]
-  
+
   if (length(signifMessage) > 0)
     someTable$addFootnote(message = paste0(signifMessage, collapse = ", "), symbol = " ")
 }
 
 .bootstrapPostHoc <- function(data, indices, options, nComparisons, postHocVariablesListV, postHocVarIndex) {
-  
+
   resamples <- data[indices, , drop = FALSE] # allows boot to select sample
 
   model <- .anovaModel(resamples, options)$model # refit model
-  
+
   postHocRefBoots <- suppressMessages(
     emmeans::lsmeans(model, postHocVariablesListV)
   )
-  
+
   postHocTableBoots <- suppressMessages(
     summary(emmeans::contrast(postHocRefBoots[[postHocVarIndex]], method = "pairwise"),
             infer = c(FALSE, FALSE))
   )
 
   progressbarTick()
-  
+
   if (nrow(postHocTableBoots) == nComparisons) {
     return(postHocTableBoots[['estimate']])
   } else{
@@ -1061,21 +1061,21 @@ Ancova <- function(jaspResults, dataset = NULL, options) {
 .anovaDunnTable <- function(postHocContainer, dataset, options, model) {
   if (!is.null(postHocContainer[["postHocDunnContainer"]]))
     return()
-  
+
   postHocDunnContainer <- createJaspContainer(title = gettext("Dunn"))
   postHocDunnContainer$dependOn(c("postHocTestsTypeDunn", "postHocFlagSignificant"))
   postHocContainer[["postHocDunnContainer"]] <- postHocDunnContainer
-  
+
   postHocVariables <- unlist(options$postHocTestsVariables, recursive = FALSE)
   postHocVariablesListV <- unname(lapply(postHocVariables, .v))
-  
+
   dunnVariables <- unique(unlist(options$postHocTestsVariables))
   dependentVar <- options$dependent
-  
+
   .createPostHocDunnTable <- function(myTitle) {
-    
+
     postHocTable <- createJaspTable(title = gettextf("Dunn's Post Hoc Comparisons - %s", myTitle))
-    
+
     postHocTable$addColumnInfo(name="contrast",   title=gettext("Comparison"),       type="string")
     postHocTable$addColumnInfo(name="z",                                             type="number")
     postHocTable$addColumnInfo(name="wA",         title=gettext("W<sub>i</sub>"),    type="number")
@@ -1083,10 +1083,10 @@ Ancova <- function(jaspResults, dataset = NULL, options) {
     postHocTable$addColumnInfo(name="pval",       title=gettext("p"),                type="pvalue")
     postHocTable$addColumnInfo(name="bonferroni", title=gettext("p<sub>bonf</sub>"), type="pvalue")
     postHocTable$addColumnInfo(name="holm",       title=gettext("p<sub>holm</sub>"), type="pvalue")
-    
+
     return(postHocTable)
   }
-    
+
   for (dunnVar in dunnVariables) {
 
     postHocDunnContainer[[dunnVar]] <- .createPostHocDunnTable(dunnVar)
@@ -1097,105 +1097,105 @@ Ancova <- function(jaspResults, dataset = NULL, options) {
                              pval = numeric(),
                              bonferroni = numeric(),
                              holm = numeric())
-    
+
     variableLevels <- levels(droplevels(dataset[[ .v(dunnVar) ]]))
     nLevels <- length(variableLevels)
     nPerGroup <- unname(unlist(table(dataset[[ .v(dunnVar) ]])))
     bigN <- sum(nPerGroup)
-    
+
     fullRanks <- rank(dataset[[ .v(dependentVar) ]])
     ranksPerGroup <- by(fullRanks, dataset[[ .v(dunnVar) ]], list)
     sumPerGroup <- unlist(lapply(ranksPerGroup, FUN = sum))
     meanPerGroup <- unname(sumPerGroup/nPerGroup)
-    
+
     tab <- table(unlist(ranksPerGroup))
     nTies <- tab[tab > 1]
     nTies <- sum(nTies^3 - nTies)
-    
+
     for (i in 1:(nLevels - 1)) {
-    
+
       for (j in (i + 1):nLevels) {
 
         contrast <- paste0(variableLevels[[i]], " - ", variableLevels[[j]])
-        
+
         sigmaAB <- sqrt( ( (bigN * (bigN + 1))/12 - nTies/(12 * (bigN - 1)) ) * (1/nPerGroup[i] + 1/nPerGroup[j] )  )
         zAB <- (meanPerGroup[i] - meanPerGroup[j]) / sigmaAB
         pValAB <- pnorm(abs(zAB), lower.tail = FALSE)
-        
-        dunnResult <- rbind(dunnResult, data.frame(contrast = contrast, 
-                                                   z = zAB, 
-                                                   wA = meanPerGroup[i], 
+
+        dunnResult <- rbind(dunnResult, data.frame(contrast = contrast,
+                                                   z = zAB,
+                                                   wA = meanPerGroup[i],
                                                    wB = meanPerGroup[j],
-                                                   pval = pValAB, 
-                                                   bonferroni = pValAB, 
+                                                   pval = pValAB,
+                                                   bonferroni = pValAB,
                                                    holm = pValAB))
-        
+
       }
-      
+
     }
-    
+
     allP <- dunnResult[["pval"]]
     dunnResult[["bonferroni"]] <- p.adjust(allP, method = "bonferroni")
     dunnResult[["holm"]] <- p.adjust(allP, method = "holm")
-    
+
     postHocDunnContainer[[dunnVar]]$setData(dunnResult)
-    
+
     if (options$postHocFlagSignificant)
-      .anovaAddSignificanceSigns(someTable = postHocDunnContainer[[dunnVar]], 
-                                 allPvalues = cbind(dunnResult[, c("pval", "bonferroni", "holm")]), 
+      .anovaAddSignificanceSigns(someTable = postHocDunnContainer[[dunnVar]],
+                                 allPvalues = cbind(dunnResult[, c("pval", "bonferroni", "holm")]),
                                  resultRowNames = rownames(dunnResult))
   }
-  
+
   return()
 }
 
 .anovaGamesTable <- function(postHocContainer, dataset, options, model) {
   if (!is.null(postHocContainer[["postHocGamesContainer"]]))
     return()
-  
+
   postHocGamesContainer <- createJaspContainer(title = gettext("Games-Howell"))
   postHocGamesContainer$dependOn(c("postHocTestsTypeGames", "confidenceIntervalIntervalPostHoc",
                                    "confidenceIntervalsPostHoc", "postHocFlagSignificant"))
   postHocContainer[["postHocGamesContainer"]] <- postHocGamesContainer
-  
+
   gamesVariables <- unique(unlist(options$postHocTestsVariables))
   dependentVar <- dataset[[ .v(options$dependent) ]]
   postHocInterval  <- options$confidenceIntervalIntervalPostHoc
-  
-  
+
+
   .createPostHocGamesTable <- function(myTitle) {
-    
+
     postHocTable <- createJaspTable(title = gettextf("Games-Howell Post Hoc Comparisons - %s", myTitle))
-    
+
     postHocTable$addColumnInfo(name="contrast", title=gettext("Comparison"),      type="string")
     postHocTable$addColumnInfo(name="meanDiff", title=gettext("Mean Difference"), type="number")
-    
+
     if (options$confidenceIntervalsPostHoc) {
       thisOverTitle <- gettextf("%.0f%% CI for Mean Difference", options$confidenceIntervalIntervalPostHoc * 100)
       postHocTable$addColumnInfo(name="lowerCI", type = "number", title = gettext("Lower"), overtitle = thisOverTitle)
       postHocTable$addColumnInfo(name="upperCI", type = "number", title = gettext("Upper"), overtitle = thisOverTitle)
     }
-    
+
     postHocTable$addColumnInfo(name="SE",                                         type="number")
     postHocTable$addColumnInfo(name="t",                                          type="number")
     postHocTable$addColumnInfo(name="df",                                         type="number")
     postHocTable$addColumnInfo(name="pTukey", title=gettext("p<sub>tukey</sub>"), type="pvalue")
-    
+
     postHocTable$showSpecifiedColumnsOnly <- TRUE
     return(postHocTable)
   }
-  
+
   for (gamesVar in gamesVariables) {
-    
+
     postHocGamesContainer[[gamesVar]] <- .createPostHocGamesTable(gamesVar)
-    
+
     groupingVar <- dataset[[ .v(gamesVar) ]]
     variableLevels <- levels(droplevels(groupingVar))
     nLevels <- length(variableLevels)
     meanPerLevel <- tapply(dependentVar, groupingVar, mean)
     nPerLevel <- tapply(dependentVar, groupingVar, length)
     varPerLevel <- tapply(dependentVar, groupingVar, var)
-    
+
     gamesResult <- data.frame(contrast = character(),
                               meanDiff = numeric(),
                               lowerCI = numeric(),
@@ -1204,22 +1204,22 @@ Ancova <- function(jaspResults, dataset = NULL, options) {
                               t = numeric(),
                               df = numeric(),
                               pTukey = numeric())
-    
+
     for (i in 1:(nLevels - 1)) {
-    
+
       for (j in (i + 1):nLevels) {
-        
+
         contrast <- paste0(variableLevels[[i]], " - ", variableLevels[[j]])
 
         meanDiff <- meanPerLevel[[i]] - meanPerLevel[[j]]
         t <- abs(meanDiff) / sqrt((varPerLevel[[i]] / nPerLevel[[i]]) + (varPerLevel[[j]] / nPerLevel[[j]]))
         se <- sqrt((varPerLevel[[i]] / nPerLevel[[i]] + varPerLevel[[j]] / nPerLevel[[j]]))
-        
-        df <- se^4 / ((varPerLevel[[i]] / nPerLevel[[i]])^2 / (nPerLevel[[i]] - 1) + 
+
+        df <- se^4 / ((varPerLevel[[i]] / nPerLevel[[i]])^2 / (nPerLevel[[i]] - 1) +
                         (varPerLevel[[j]] / nPerLevel[[j]])^2 / (nPerLevel[[j]] - 1))
-        
+
         pVal <- ptukey(t * sqrt(2), nLevels, df, lower.tail = FALSE)
-        
+
         upperConf <- meanDiff + qtukey(p = postHocInterval, nmeans = nLevels, df = df) * se * sqrt(0.5)
         lowerConf <- meanDiff - qtukey(p = postHocInterval, nmeans = nLevels, df = df) * se * sqrt(0.5)
 
@@ -1233,7 +1233,7 @@ Ancova <- function(jaspResults, dataset = NULL, options) {
                                                      pTukey = pVal))
       }
     }
-    
+
     postHocGamesContainer[[gamesVar]]$setData(gamesResult)
 
     if (options$postHocFlagSignificant)
@@ -1242,57 +1242,57 @@ Ancova <- function(jaspResults, dataset = NULL, options) {
                                  resultRowNames = rownames(gamesResult))
 
   }
-  
+
   return()
 }
 
 .anovaDunnettTable <- function(postHocContainer, dataset, options, model) {
   if (!is.null(postHocContainer[["postHocDunnettContainer"]]))
     return()
-  
+
   postHocDunnettContainer <- createJaspContainer(title = gettext("Dunnett"))
   postHocDunnettContainer$dependOn(c("postHocTestsTypeDunnett", "confidenceIntervalIntervalPostHoc",
                                      "confidenceIntervalsPostHoc", "postHocFlagSignificant"))
   postHocContainer[["postHocDunnettContainer"]] <- postHocDunnettContainer
-  
+
   dunnettVariables <- unique(unlist(options$postHocTestsVariables))
   dependentVariable <- dataset[[ .v(options$dependent) ]]
-  
+
   .createPostHocDunnettTable <- function(myTitle) {
-    
+
     postHocTable <- createJaspTable(title = gettextf("Dunnett Post Hoc Comparisons - %s", myTitle))
-    
+
     postHocTable$addColumnInfo(name="contrast",title=gettext("Comparison"),      type="string")
     postHocTable$addColumnInfo(name="meanDiff",title=gettext("Mean Difference"), type="number")
-    
+
     if (options$confidenceIntervalsPostHoc) {
       thisOverTitle <- gettextf("%s%% CI for Mean Difference", options$confidenceIntervalIntervalPostHoc * 100)
       postHocTable$addColumnInfo(name="lowerCI", type = "number", title = gettext("Lower"), overtitle = thisOverTitle)
       postHocTable$addColumnInfo(name="upperCI", type = "number", title = gettext("Upper"), overtitle = thisOverTitle)
     }
-    
+
     postHocTable$addColumnInfo(name="SE", type="number")
     postHocTable$addColumnInfo(name="t", type="number")
     postHocTable$addColumnInfo(name="p", title=gettext("p<sub>dunnett</sub>"), type="pvalue")
-    
+
     postHocTable$showSpecifiedColumnsOnly <- TRUE
-    
+
     return(postHocTable)
   }
-  
+
   for (dunnettVar in dunnettVariables) {
-    
+
     postHocDunnettContainer[[dunnettVar]] <- .createPostHocDunnettTable(dunnettVar)
-    
+
     Group <- dataset[[ .v(dunnettVar) ]]
     nLevels <- length(unique(Group))
-    
+
     dunAOV <- aov(dependentVariable ~ Group)
 
     dunnettFit <- multcomp::glht(dunAOV, linfct=multcomp::mcp(Group="Dunnett"))
     dunnettResult <- summary(dunnettFit)[["test"]]
     dunnettConfInt <- try(confint(dunnettFit, level = options$confidenceIntervalIntervalPostHoc), silent = TRUE)
-    
+
     if (options$confidenceIntervalsPostHoc && class(dunnettConfInt) == "try-error") {
       postHocDunnettContainer$setError(gettext("Confidence interval is too narrow, please select a different confidence level."))
     } else {
@@ -1303,17 +1303,17 @@ Ancova <- function(jaspResults, dataset = NULL, options) {
                                   SE = dunnettResult$sigma,
                                   t = dunnettResult$tstat,
                                   p = dunnettResult$pvalues)
-      
+
       postHocDunnettContainer[[dunnettVar]]$setData(dunnettResult)
 
       if (options$postHocFlagSignificant)
-        .anovaAddSignificanceSigns(someTable = postHocDunnettContainer[[dunnettVar]], 
-                                   allPvalues = dunnettResult["p"], 
+        .anovaAddSignificanceSigns(someTable = postHocDunnettContainer[[dunnettVar]],
+                                   allPvalues = dunnettResult["p"],
                                    resultRowNames = rownames(dunnettResult))
-      
+
     }
   }
-  
+
   return()
 }
 
@@ -1325,76 +1325,76 @@ Ancova <- function(jaspResults, dataset = NULL, options) {
   anovaContainer[["descriptivesTable"]] <- descriptivesTable
 
   for (variable in options$fixedFactors) {
-    
+
     name <- paste0(variable, "_DescriptivesVar")  # in case variable is "Mean", "SD" or "N"
     descriptivesTable$addColumnInfo(title = variable, name = name, type = "string", combine = TRUE)
-    
+
   }
-  
+
   descriptivesTable$addColumnInfo(name = "Mean", title=gettext("Mean"), type = "number")
   descriptivesTable$addColumnInfo(name = "SD",   title=gettext("SD"),   type = "number")
   descriptivesTable$addColumnInfo(name = "N",    title=gettext("N"),    type = "integer")
-  
+
   lvls <- list()
   factors <- list()
-  
+
   for (variable in options$fixedFactors) {
-    
+
     factor <- dataset[[ .v(variable) ]]
     factors[[length(factors)+1]] <- factor
     lvls[[ variable ]] <- levels(factor)
-    
+
   }
-  
+
   descriptiveResult <- rev(expand.grid(rev(lvls), stringsAsFactors = FALSE))
   descriptiveResult[[".isNewGroup"]] <- FALSE
-  
+
   columnNames <- paste0(unlist(options$fixedFactors), "_DescriptivesVar")
   nSubsetVars <- length(columnNames)
-  
+
   allSubsets <- list()
-  
+
   for (i in 1:nrow(descriptiveResult)) {
     # Here we generate a logical statement to make of a subset of all relevant variables
-    subsetStatement  <- eval(parse(text=paste("dataset$", .v(unlist(options$fixedFactors)), " == \"", 
-                                              descriptiveResult[i, 1:nSubsetVars], 
+    subsetStatement  <- eval(parse(text=paste("dataset$", .v(unlist(options$fixedFactors)), " == \"",
+                                              descriptiveResult[i, 1:nSubsetVars],
                                               "\"", sep = "", collapse = " & ")))
-    
+
     # Now we use that statement to make a subset and store in the list of all subsets
     allSubsets[[i]] <- base::subset(dataset, subsetStatement, select = .v(options$dependent))[[1]]
-    
+
     if (descriptiveResult[i, nSubsetVars] == lvls[[ nSubsetVars ]][1]) {
       descriptiveResult[[i, ".isNewGroup"]] <- TRUE
     }
   }
-  
+
   allMeans <- sapply(allSubsets, mean)
   descriptiveResult[["Mean"]] <- ifelse(is.nan(allMeans), NA, allMeans)
   descriptiveResult[["N"]]    <- sapply(allSubsets, length)
   descriptiveResult[["SD"]]   <- sapply(allSubsets, sd)
-  
+
   colnames(descriptiveResult)[1:nSubsetVars] <- columnNames
-  
+
   descriptivesTable$setData(descriptiveResult)
-  
+
   return()
 }
 
 .anovaAssumptionsContainer <- function(anovaContainer, dataset, options, ready) {
   if (!is.null(anovaContainer[["assumptionsContainer"]]))
     return()
-  
+
   assumptionsContainer <- createJaspContainer(title = gettext("Assumption Checks"),
                                               dependencies = c("homogeneityTests", "qqPlot"))
 
   anovaContainer[["assumptionsContainer"]] <- assumptionsContainer
-  
+
   if (options$homogeneityTests == TRUE)
     .anovaLevenesTable(anovaContainer, dataset, options, ready)
-  
+
   if (options$qqPlot == TRUE)
     .qqPlot(anovaContainer, dataset, options, ready)
-  
+
   return()
 }
 
@@ -1406,28 +1406,28 @@ Ancova <- function(jaspResults, dataset = NULL, options) {
   leveneTable$addColumnInfo(name="df1", title=gettext("df1"), type="number")
   leveneTable$addColumnInfo(name="df2", title=gettext("df2"), type="number")
   leveneTable$addColumnInfo(name="p",   title=gettext("p"),   type="pvalue")
-  
-  
+
+
   if (options$VovkSellkeMPR) {
     leveneTable$addColumnInfo(title = gettextf("VS-MPR%s", "\u002A"), name = "VovkSellkeMPR", type = "number")
     leveneTable$addFootnote(message = .messages("footnote", "VovkSellkeMPR"), symbol = "\u002A")
   }
-  
+
   leveneTable$showSpecifiedColumnsOnly <- TRUE
-  
+
   anovaContainer[["assumptionsContainer"]][["leveneTable"]] <- leveneTable
-  
+
   if (!ready || anovaContainer$getError())
     return()
-  
+
   # Start Levene computations
   model <- anovaContainer[["model"]]$object
   interaction <- paste(.v(options$fixedFactors), collapse=":", sep="")
   resids <- abs(model$residuals)
-  
+
   leveneResult <- summary(aov(as.formula(paste("resids", "~", interaction)), dataset))[[1]]
   error <- base::tryCatch(summary(aov(levene.formula, dataset)),error=function(e) e, warning=function(w) w)
-  
+
   if (!is.null(error$message) && error$message == "ANOVA F-tests on an essentially perfect fit are unreliable") {
     leveneTable$setError(gettext("F-value equal to zero indicating perfect fit.<br><br>(Levene's tests on an essentially perfect fit are unreliable)"))
     return()
@@ -1449,64 +1449,64 @@ Ancova <- function(jaspResults, dataset = NULL, options) {
   marginalMeansContainer <- createJaspContainer(title = gettext("Marginal Means"))
   marginalMeansContainer$dependOn(c("marginalMeansTerms",  "marginalMeansCompareMainEffects", "marginalMeansCIAdjustment",
                                     "marginalMeansBootstrapping", "marginalMeansBootstrappingReplicates"))
-  
+
   anovaContainer[["marginalMeansContainer"]] <- marginalMeansContainer
-  
+
   model <- anovaContainer[["model"]]$object
-  
+
   terms <- options$marginalMeansTerms
-  
+
   marginalVariables <- unlist(options$marginalMeansTerms, recursive = FALSE)
   marginalVariablesListV <- unname(lapply(marginalVariables, .v))
-  
+
   for (i in seq_along(marginalVariables)) {
     thisVarName <- paste(marginalVariables[[i]], collapse = " \u273B ")
     individualTerms <- marginalVariables[[i]]
-    marginalMeansContainer[[thisVarName]] <- .createMarginalMeansTableAnova(thisVarName, options, individualTerms, 
+    marginalMeansContainer[[thisVarName]] <- .createMarginalMeansTableAnova(thisVarName, options, individualTerms,
                                                                             options[["marginalMeansBootstrapping"]])
   }
-  
-  
+
+
   terms.base64 <- c()
   terms.normal <- c()
-  
+
   for (term in terms) {
-    
+
     components <- unlist(term)
     term.base64 <- paste(.v(components), collapse=":", sep="")
     term.normal <- paste(components, collapse=" \u273B ", sep="")
-    
+
     terms.base64 <- c(terms.base64, term.base64)
     terms.normal <- c(terms.normal, term.normal)
   }
-  
+
 
   for (i in seq_along(marginalVariables)) {
 
     thisVarName <- paste(marginalVariables[[i]], collapse = " \u273B ")
     thisTermNameV <- paste(marginalVariablesListV[[i]], collapse = ":")
-    
+
     individualTerms <- marginalVariables[[i]]
-    
+
     lvls <- list()
     factors <- list()
 
     for (variable in individualTerms) {
-      
+
       factor <- dataset[[ .v(variable) ]]
       factors[[length(factors) + 1]] <- factor
       lvls[[variable]] <- levels(factor)
-      
+
     }
-    
+
     cases <- rev(expand.grid(rev(lvls)))
     cases <- as.data.frame(apply(cases, 2, as.character))
-    
+
     nRows <- dim(cases)[1]
     nCol <- dim(cases)[2]
-    
+
     formula <- as.formula(paste("~", thisTermNameV))
-    
+
     if(options$marginalMeansCIAdjustment == "bonferroni") {
       adjMethod <- "bonferroni"
     } else if(options$marginalMeansCIAdjustment == "sidak") {
@@ -1514,32 +1514,32 @@ Ancova <- function(jaspResults, dataset = NULL, options) {
     } else {
       adjMethod <- "none"
     }
-    
+
     marginalResult <- summary(emmeans::lsmeans(model, formula), adjust = adjMethod, infer = c(TRUE,TRUE))
-    
+
     marginalResult[[".isNewGroup"]] <- FALSE
     marginalResult[[".isNewGroup"]][which(marginalResult[, 1] == marginalResult[1, 1])] <- TRUE
-    
+
     names(marginalResult)[1:length(individualTerms)] <- individualTerms
-    
+
     if (options$marginalMeansBootstrapping) {
-      
+
       startProgressbar(options[["marginalMeansBootstrappingReplicates"]],
                        label = gettext("Bootstrapping Marginal Means"))
 
       anovaFormula <- as.formula(paste("~", terms.base64[i]))
-      bootstrapMarginalMeans <- try(boot::boot(data = dataset, statistic = .bootstrapMarginalMeans, 
+      bootstrapMarginalMeans <- try(boot::boot(data = dataset, statistic = .bootstrapMarginalMeans,
                                                R = options[["marginalMeansBootstrappingReplicates"]],
-                                               options = options, nRows = nRows, 
+                                               options = options, nRows = nRows,
                                                anovaFormula = anovaFormula), silent = TRUE)
-      
+
       if (class(bootstrapMarginalMeans) == "try-error") {
         marginalMeansContainer[[thisVarName]]$setError(bootstrapMarginalMeans)
         next
       }
-      
+
       bootstrapSummary <- summary(bootstrapMarginalMeans)
-      
+
       ci.fails <- FALSE
       bootstrapMarginalMeansCI <- t(sapply(1:nrow(bootstrapSummary), function(index){
         res <- try(boot::boot.ci(boot.out = bootstrapMarginalMeans, conf = 0.95, type = "bca",
@@ -1551,37 +1551,37 @@ Ancova <- function(jaspResults, dataset = NULL, options) {
           return(c(NA, NA))
         }
       }))
-      
+
       if(ci.fails)
         marginalMeansContainer[[thisVarName]]$addFootnote(message = gettext("Some confidence intervals could not be computed. Possibly too few bootstrap replicates."))
-      
+
       marginalResult[["lower.CL"]] <- bootstrapMarginalMeansCI[,1]
       marginalResult[["upper.CL"]] <- bootstrapMarginalMeansCI[,2]
-      
+
       marginalResult[["bias"]] <- bootstrapSummary[["bootBias"]]
       marginalResult[["SE"]] <- bootstrapSummary[["bootSE"]]
       marginalResult[["lsmean"]] <- bootstrapSummary[["bootMed"]]
-      
+
       marginalMeansContainer[[thisVarName]]$addFootnote(message = gettextf("Bootstrapping based on %s replicates.", as.character(bootstrapSummary$R[1])))
     }
     marginalMeansContainer[[thisVarName]]$setData(marginalResult)
   }
-  
+
   return()
 }
 
 .bootstrapMarginalMeans <- function(data, indices, options, nRows, anovaFormula){
-  
+
   resamples <- data[indices, , drop=FALSE]
 
   model <- .anovaModel(resamples, options)$model # refit model
-  
+
   r <- suppressMessages( # to remove clutter
     summary(emmeans::lsmeans(model, anovaFormula), infer = c(FALSE,FALSE))
   )
-  
+
   progressbarTick()
-  
+
   if(length(r$lsmean) == nRows){ # ensure that the bootstrap has all levels
     return(r$lsmean)
   } else {
@@ -1590,32 +1590,32 @@ Ancova <- function(jaspResults, dataset = NULL, options) {
 }
 
 .anovaSimpleEffects <- function(anovaContainer, dataset, options, ready) {
-  if (!is.null(anovaContainer[["simpleEffectsContainer"]]) || identical(options$simpleFactor, "") || 
+  if (!is.null(anovaContainer[["simpleEffectsContainer"]]) || identical(options$simpleFactor, "") ||
       identical(options$moderatorFactorOne, ""))
     return()
 
   anovaContainer[["simpleEffectsContainer"]] <- createJaspContainer(title = gettext("Simple Main Effects"),
-                                                                    dependencies = c("simpleFactor", 
-                                                                                     "moderatorFactorOne", 
+                                                                    dependencies = c("simpleFactor",
+                                                                                     "moderatorFactorOne",
                                                                                      "moderatorFactorTwo"))
   simpleEffectsTable <- createJaspTable(title = gettextf("Simple Main Effects - %s", options$simpleFactor))
 
   anovaContainer[["simpleEffectsContainer"]][["simpleEffectsTable"]] <- simpleEffectsTable
-  
+
   moderatorTerms <- c(options$moderatorFactorOne, options$moderatorFactorTwo[!identical(options$moderatorFactorTwo, "")])
   nMods <- length(moderatorTerms)
   simpleFactorBase64 <- .v(options$simpleFactor)
 
   simpleEffectsTable[["title"]] <- gettextf("Simple Main Effects - %s", options$simpleFactor)
-  
+
   simpleEffectsTable$addColumnInfo(name = "modOne", title = gettextf("Level of %s", moderatorTerms[1]),
                                    type = "string", combine = TRUE)
-  
+
   if (nMods == 2)
     simpleEffectsTable$addColumnInfo(name = "modTwo", title = gettextf("Level of %s", moderatorTerms[2]),
                                    type = "string", combine = TRUE)
-  
-  
+
+
   simpleEffectsTable$addColumnInfo(name = "Sum Sq",  type = "number",  title = gettext("Sum of Squares"))
   simpleEffectsTable$addColumnInfo(name = "Df",      type = "integer", title = gettext("df"))
   simpleEffectsTable$addColumnInfo(name = "Mean Sq", type = "number",  title = gettext("Mean Square"))
@@ -1624,7 +1624,7 @@ Ancova <- function(jaspResults, dataset = NULL, options) {
 
   simpleEffectsTable$showSpecifiedColumnsOnly <- TRUE
 
-  if (!ready || anovaContainer$getError()) 
+  if (!ready || anovaContainer$getError())
     return()
 
   fullAnovaMS <- anovaContainer[["anovaResult"]]$object$result["Residuals", "Mean Sq"]
@@ -1632,18 +1632,18 @@ Ancova <- function(jaspResults, dataset = NULL, options) {
 
   # Remove moderator factors from model terms
   simpleOptions <- options
-  simpleOptions$modelTerms <-  options$modelTerms[!(grepl(moderatorTerms[1], options$modelTerms) | 
+  simpleOptions$modelTerms <-  options$modelTerms[!(grepl(moderatorTerms[1], options$modelTerms) |
                                                       grepl(moderatorTerms[nMods], options$modelTerms))]
   simpleOptions$fixedFactors <- options$fixedFactors[!(grepl(moderatorTerms[1], options$fixedFactors) |
                                                          grepl(moderatorTerms[nMods], options$fixedFactors))]
-  
+
   # simpleOptions$covariates <- NULL
   # simpleOptions$modelTerms <- list(list(components = "facExperim"))
   lvls <- list()
   factors <- list()
 
   for (variable in moderatorTerms) {
-    
+
     factor <- dataset[[ .v(variable) ]]
     factors[[length(factors)+1]] <- factor
     lvls[[variable]] <- levels(factor)
@@ -1651,38 +1651,38 @@ Ancova <- function(jaspResults, dataset = NULL, options) {
 
   simpleEffectResult <- rev(expand.grid(rev(lvls), stringsAsFactors = FALSE))
   colnames(simpleEffectResult) <- c("modOne", "modTwo")[1:nMods]
-  
+
   simpleEffectResult[[".isNewGroup"]] <- c(TRUE, rep(FALSE, nrow(simpleEffectResult)-1))
   emptyCaseIndices <- emptyCases <- NULL
   allSimpleModels <- list()
-  
+
   for (i in 1:nrow(simpleEffectResult)) {
 
-    subsetStatement  <- eval(parse(text=paste("dataset$", .v(moderatorTerms), " == \"", 
-                                              simpleEffectResult[i, 1:nMods], 
+    subsetStatement  <- eval(parse(text=paste("dataset$", .v(moderatorTerms), " == \"",
+                                              simpleEffectResult[i, 1:nMods],
                                               "\"", sep = "", collapse = " & ")))
     simpleDataset <- base::subset(dataset, subsetStatement)
-    
+
     if (simpleEffectResult[i, nMods] == lvls[[ nMods ]][1] && nMods == 2)
       simpleEffectResult[[i, ".isNewGroup"]] <- TRUE
-    
-    if (nrow(simpleDataset) < 2 || 
+
+    if (nrow(simpleDataset) < 2 ||
         nrow(unique(simpleDataset[simpleFactorBase64])) <  nrow(unique(dataset[simpleFactorBase64]))) {
-      
+
       emptyCaseIndices <- c(emptyCaseIndices, i)
       emptyCases <- c(emptyCases, paste(simpleEffectResult[i, 1:nMods], collapse = ", "))
       allSimpleModels[[i]] <- NA
-      
+
     } else {
 
       .anovaModelContainer(anovaContainer[["simpleEffectsContainer"]], dataset = simpleDataset, options = simpleOptions, TRUE)
       .anovaResult(anovaContainer[["simpleEffectsContainer"]], options = simpleOptions)
       simpleResult <- anovaContainer[["simpleEffectsContainer"]][["anovaResult"]]$object$result
       simpleResult[[".isNewGroup"]] <- NULL
-      
+
       allSimpleModels[[i]] <- simpleResult[simpleFactorBase64, ]
       anovaContainer[["simpleEffectsContainer"]][["model"]] <- NULL
-      
+
     }
   }
 
@@ -1696,48 +1696,48 @@ Ancova <- function(jaspResults, dataset = NULL, options) {
 
   # Apply corrections to F and p based on the original ANOVA
   simpleEffectResult[["F value"]] <- simpleEffectResult[["Mean Sq"]] / fullAnovaMS
-  simpleEffectResult[["Pr(>F)"]] <-  pf(simpleEffectResult[["F value"]], simpleEffectResult[["Df"]], 
+  simpleEffectResult[["Pr(>F)"]] <-  pf(simpleEffectResult[["F value"]], simpleEffectResult[["Df"]],
                                         fullAnovaDf, lower.tail = FALSE)
 
   simpleEffectsTable$setData(simpleEffectResult)
-  
-  return()  
+
+  return()
 }
 
 .anovaKruskal <- function(anovaContainer, dataset, options, ready) {
   if (!is.null(anovaContainer[["kruskalContainer"]]) || !length(options$kruskalVariablesAssigned))
     return()
-  
-  
+
+
   anovaContainer[["kruskalContainer"]] <- createJaspContainer(title = gettext("Kruskal-Wallis Test"),
                                                               dependencies = "kruskalVariablesAssigned")
   kruskalTable <- createJaspTable(title = gettext("Kruskal-Wallis Test"))
 
   anovaContainer[["kruskalContainer"]][["kruskalTable"]] <- kruskalTable
-  
+
   kruskalTable$addColumnInfo(name = "Factor",    title=gettext("Factor"),    type = "string")
   kruskalTable$addColumnInfo(name = "Statistic", title=gettext("Statistic"), type = "number")
   kruskalTable$addColumnInfo(name = "df",        title=gettext("df"),        type = "integer")
   kruskalTable$addColumnInfo(name = "p",         title=gettext("p"),         type = "pvalue")
-  
-  
-  if (!ready || anovaContainer$getError()) 
+
+
+  if (!ready || anovaContainer$getError())
     return()
-  
+
   kruskalFactors <- options$kruskalVariablesAssigned
   kruskalResultsList <- list()
-  
+
   for (term in kruskalFactors) {
 
     kruskalResultsList[[term]] <- kruskal.test(dataset[[.v(options$dependent)]], dataset[[.v(term)]])
-    
+
   }
 
   kruskalTable$setData(data.frame(Factor = names(kruskalResultsList),
                                   Statistic = sapply(kruskalResultsList, function(x) x$statistic),
                                   df = sapply(kruskalResultsList, function(x) x$parameter),
                                   p = sapply(kruskalResultsList, function(x) x$p.value)))
- 
+
   return()
 }
 
@@ -1745,25 +1745,25 @@ Ancova <- function(jaspResults, dataset = NULL, options) {
 
   # create the jaspPlot object
   qqPlot <- createJaspPlot(title = gettext("Q-Q Plot"), width = options$plotWidthQQPlot, height = options$plotHeightQQPlot)
-  
+
   # now we assign the plot to jaspResults
   anovaContainer[["assumptionsContainer"]][["qqPlot"]] <- qqPlot
-  
+
   if (!ready || anovaContainer$getError())
     return()
-  
+
   model <- anovaContainer[["model"]]$object
   standResid <- as.data.frame(stats::qqnorm(rstandard(model), plot.it=FALSE))
-  
+
   standResid <- na.omit(standResid)
   xVar <- standResid$x
   yVar <- standResid$y
-  
+
   # Format x ticks
   xlow <- min(pretty(xVar))
   xhigh <- max(pretty(xVar))
   xticks <- pretty(c(xlow, xhigh))
-  
+
   # format x labels
   xLabs <- vector("character", length(xticks))
   for (i in seq_along(xticks)) {
@@ -1773,16 +1773,16 @@ Ancova <- function(jaspResults, dataset = NULL, options) {
       xLabs[i] <- format(xticks[i], digits= 3, scientific = TRUE)
     }
   }
-  
+
   # Format y ticks
   ylow <- min(pretty(yVar))
-  yhigh <- max(pretty(yVar))        
+  yhigh <- max(pretty(yVar))
   yticks <- pretty(c(ylow, yhigh))
-  
+
   # format axes labels
   xLabs <- jaspGraphs::axesLabeller(xticks)
   yLabs <- jaspGraphs::axesLabeller(yticks)
-    
+
   # format y labels
   yLabs <- vector("character", length(yticks))
   for (i in seq_along(yticks)) {
@@ -1792,23 +1792,23 @@ Ancova <- function(jaspResults, dataset = NULL, options) {
       yLabs[i] <- format(yticks[i], digits= 3, scientific = TRUE)
     }
   }
-  
+
   p <- jaspGraphs::drawAxis(xName = gettext("Theoretical Quantiles"),
                             yName = gettext("Standardized Residuals"),
-                            xBreaks = xticks, 
-                            yBreaks = xticks, 
-                            yLabels = xLabs, 
-                            xLabels = xLabs, 
+                            xBreaks = xticks,
+                            yBreaks = xticks,
+                            yLabels = xLabs,
+                            xLabels = xLabs,
                             force = TRUE)
-  
-  p <- p + ggplot2::geom_line(data = data.frame(x = c(min(xticks), max(xticks)), y = c(min(xticks), max(xticks))), 
-                              mapping = ggplot2::aes(x = x, y = y), 
-                              col = "darkred", 
+
+  p <- p + ggplot2::geom_line(data = data.frame(x = c(min(xticks), max(xticks)), y = c(min(xticks), max(xticks))),
+                              mapping = ggplot2::aes(x = x, y = y),
+                              col = "darkred",
                               size = 1)
-  
+
   p <- jaspGraphs::drawPoints(p, dat = data.frame(xVar, yVar), size = 3)
 
   qqPlot$plotObject <- jaspGraphs::themeJasp(p)
-  
+
   return()
 }

--- a/R/ancova.R
+++ b/R/ancova.R
@@ -925,10 +925,8 @@ Ancova <- function(jaspResults, dataset = NULL, options) {
     colnames(allPvalues) <- postHocCorrections
     resultPostHoc <- cbind(resultPostHoc[[1]], allPvalues)
 
-    resultPostHoc[["contrast_A"]] <- lapply(allContrasts, function(x) paste(.unv(strsplit(x[[1]], "[ ,]")[[1]]), 
-                                                                           collapse = ", "))
-    resultPostHoc[["contrast_B"]] <- lapply(allContrasts, function(x) paste(.unv(strsplit(x[[2]], "[ ,]")[[1]]), 
-                                                                           collapse = ", "))
+    resultPostHoc[["contrast_A"]] <- lapply(allContrasts, function(x) paste(strsplit(x[[1]], "[ ,]")[[1]], collapse = ", "))
+    resultPostHoc[["contrast_B"]] <- lapply(allContrasts, function(x) paste(strsplit(x[[2]], "[ ,]")[[1]], collapse = ", "))
 
     if (options$postHocTestsBootstrapping) {
 

--- a/R/ancova.R
+++ b/R/ancova.R
@@ -925,8 +925,8 @@ Ancova <- function(jaspResults, dataset = NULL, options) {
     colnames(allPvalues) <- postHocCorrections
     resultPostHoc <- cbind(resultPostHoc[[1]], allPvalues)
 
-    resultPostHoc[["contrast_A"]] <- lapply(allContrasts, function(x) paste(strsplit(x[[1]], "[ ,]")[[1]], collapse = ", "))
-    resultPostHoc[["contrast_B"]] <- lapply(allContrasts, function(x) paste(strsplit(x[[2]], "[ ,]")[[1]], collapse = ", "))
+    resultPostHoc[["contrast_A"]] <- lapply(allContrasts, `[[`, 1L)
+    resultPostHoc[["contrast_B"]] <- lapply(allContrasts, `[[`, 2L)
 
     if (options$postHocTestsBootstrapping) {
 

--- a/tests/testthat/test-anova.R
+++ b/tests/testthat/test-anova.R
@@ -83,9 +83,9 @@ test_that("Contrasts table results match", {
 
   refTables <- list(
     deviation = list("2 - 1, 2, 3, 4, 5", -0.19513913461, 0.211517937182489, -0.922565420263351, 0.358570880186821,
-                      95, -0.615055331660948, 0.224777062440949, "TRUE", "3 - 1, 2, 3, 4, 5", 0.331498558639999, 
-                     0.211517937182488, 1.56723615526752, 0.120384543718471, 95, -0.0884176384109483, 0.751414755690946, 
-                     "FALSE", "4 - 1, 2, 3, 4, 5", -0.16911442746, 0.211517937182488, -0.799527594267789, 0.425979159402386, 
+                      95, -0.615055331660948, 0.224777062440949, "TRUE", "3 - 1, 2, 3, 4, 5", 0.331498558639999,
+                     0.211517937182488, 1.56723615526752, 0.120384543718471, 95, -0.0884176384109483, 0.751414755690946,
+                     "FALSE", "4 - 1, 2, 3, 4, 5", -0.16911442746, 0.211517937182488, -0.799527594267789, 0.425979159402386,
                      95, -0.589030624510948, 0.250801769590948, "FALSE", "5 - 1, 2, 3, 4, 5", 0.18254372644, 0.211517937182488,
                      0.863017713162119, 0.390301247101766, 95, -0.237372470610948, 0.602459923490948, "FALSE"),
     simple = list("2 - 1", -0.0453504116000002, 0.334439223738541, -0.135601354090735,
@@ -294,11 +294,11 @@ test_that("Nonparametric table results match", {
   options$modelTerms <- list(
     list(components="facExperim"),
     list(components="facFive")
-  )  
+  )
   results <- jaspTools::runAnalysis("Anova", "test.csv", options)
   table <- results[["results"]]$anovaContainer$collection$anovaContainer_kruskalContainer$collection$anovaContainer_kruskalContainer_kruskalTable$data
   jaspTools::expect_equal_tables(table,
-                      list("facFive", 3.39599999999996, 4, 0.493866894607871, "facExperim",       
+                      list("facFive", 3.39599999999996, 4, 0.493866894607871, "facExperim",
                            1.02696237623763, 1, 0.310873187457312)
   )
 })
@@ -318,7 +318,7 @@ test_that("Analysis handles errors", {
   options$wlsWeights <- "debInf"
   options$modelTerms <- list(list(components="contBinom"))
   results <- jaspTools::runAnalysis("Anova", "test.csv", options)
-  expect_identical(results[["results"]][["errorMessage"]], 
+  expect_identical(results[["results"]][["errorMessage"]],
                    "The following problem(s) occurred while running the analysis:<ul><li>Infinity found in debInf</li></ul>",
                   label="Inf WLS weights check")
   options$wlsWeights <- ""
@@ -327,7 +327,7 @@ test_that("Analysis handles errors", {
   options$fixedFactors <- "debSame"
   options$modelTerms <- list(list(components="debSame"))
   results <- jaspTools::runAnalysis("Anova", "test.csv", options)
-  expect_identical(results[["results"]][["errorMessage"]], 
+  expect_identical(results[["results"]][["errorMessage"]],
                    "The following problem(s) occurred while running the analysis:<ul><li>Number of factor levels is < 2 in debSame</li></ul>",
                   label="1-level factor check")
 
@@ -335,7 +335,7 @@ test_that("Analysis handles errors", {
   options$fixedFactors <- "facFive"
   options$modelTerms <- list(list(components="facFive"))
   results <- jaspTools::runAnalysis("Anova", "test.csv", options)
-  expect_identical(results[["results"]][["errorMessage"]], 
+  expect_identical(results[["results"]][["errorMessage"]],
                    "The following problem(s) occurred while running the analysis:<ul><li>The variance in debSame is equal to 0 after grouping on facFive</li></ul>",
                   label="No variance check")
 
@@ -344,7 +344,7 @@ test_that("Analysis handles errors", {
   options$wlsWeights <- "contNormal"
   options$modelTerms <- list(list(components="facFive"))
   results <- jaspTools::runAnalysis("Anova", "test.csv", options)
-  expect_identical(results[["results"]][["errorMessage"]], 
+  expect_identical(results[["results"]][["errorMessage"]],
                    "The following problem(s) occurred while running the analysis:<ul><li>The WLS weights contain negative and/or zero values.<br><br>(only positive WLS weights allowed).</li></ul>",
                   label="Negative WLS weights check")
 })
@@ -357,11 +357,11 @@ test_that("Field - Chapter 4 results match", {
   options$dependent <- "Happiness"
   options$fixedFactors <- "Dose"
   options$modelTerms <- list(list(components = "Dose"))
-  
+
   options$homogeneityCorrections <- TRUE
   options$homogeneityBrown <- TRUE
   options$homogeneityWelch <- TRUE
-  
+
   results <- jaspTools::runAnalysis("Anova", "Puppies Dummy.csv", options)
   table <- results[["results"]][["anovaContainer"]][["collection"]][["anovaContainer_anovaTable"]][["data"]]
 
@@ -384,26 +384,26 @@ test_that("Field - Chapter 5 results match", {
   options$dependent <- "Happiness"
   options$fixedFactors <- "Dose"
   options$modelTerms <- list(list(components = "Dose"))
-  
+
   options$contrasts <- list(
     list(contrast = "Helmert", variable = "Dose")
-  )  
+  )
   options$confidenceIntervalsContrast <- TRUE
-  
+
   options$postHocTestsVariables <- "Dose"
   options$postHocTestsTypeGames <- TRUE
   options$postHocTestsTypeDunnett <- TRUE
   options$confidenceIntervalsPostHoc <- TRUE
   results <- jaspTools::runAnalysis("Anova", "Puppies Dummy.csv", options)
-  
-  # contrast 
+
+  # contrast
   table <- results[["results"]]$anovaContainer$collection$anovaContainer_contrastContainer$collection[[1]]$collection[[1]]$data
   jaspTools::expect_equal_tables(table,
                       list("1 - 2, 3", -1.9, 0.768114574786861, -2.47358930863565, 0.0293002196554282,
                            12, -3.5735778902, -0.2264221098, "TRUE", "2 - 3", -1.8, 0.886942313043338,
                            -2.02944427560764, 0.0651922067570462, 12, -3.73248129083355,
                            0.132481290833552, "FALSE"))
-  
+
   # standard post hoc (tukey)
   table <- results[["results"]]$anovaContainer$collection$anovaContainer_postHocContainer$collection$anovaContainer_postHocContainer_postHocStandardContainer$collection$anovaContainer_postHocContainer_postHocStandardContainer_Dose$data
   jaspTools::expect_equal_tables(table,
@@ -413,7 +413,7 @@ test_that("Field - Chapter 5 results match", {
                            -5.16624115850686, -0.433758841493135, "FALSE",
                            2, 3, -1.8, 0.886942313043338, -2.02944427560764, 0.147457622995377,
                            -4.16624115850686, 0.566241158506865, "FALSE"))
-  
+
   # games-howell post hoc
   table <- results[["results"]]$anovaContainer$collection$anovaContainer_postHocContainer$collection$anovaContainer_postHocContainer_postHocGamesContainer$collection$anovaContainer_postHocContainer_postHocGamesContainer_Dose$data
   jaspTools::expect_equal_tables(table,
@@ -422,10 +422,10 @@ test_that("Field - Chapter 5 results match", {
                           0.916515138991168, -5.43893919399355, -0.161060806006447, 0.0388414107946456,
                           7.7199124726477, "2 - 3", -1.8, -1.96396101212393, 0.916515138991168,
                           -4.43893919399355, 0.838939193993553, 0.185393344481167, 7.7199124726477))
-  
+
   # dunnet post hoc
   table <- results[["results"]]$anovaContainer$collection$anovaContainer_postHocContainer$collection$anovaContainer_postHocContainer_postHocDunnettContainer$collection$anovaContainer_postHocContainer_postHocDunnettContainer_Dose$data
-  jaspTools::expect_equal_tables(table, 
+  jaspTools::expect_equal_tables(table,
                       list("2 - 1", 1, 1.12746904200424, 0.886942313043338, 0.445888579780104,
                            -1.21963511399532, 3.21963511399532, "3 - 1", 2.8, 3.15691331761188,
                            0.886942313043338, 0.0152377020148067, 0.580364886004677, 5.01963511399532))
@@ -435,7 +435,7 @@ test_that("Field - Chapter 5 results match", {
 
 test_that("Field - Chapter 7 results match", {
   options <- jaspTools::analysisOptions("Anova")
-  
+
   options$dependent <- "Attractiveness"
   options$fixedFactors <- list("FaceType", "Alcohol")
   options$modelTerms <- list(
@@ -443,28 +443,28 @@ test_that("Field - Chapter 7 results match", {
     list(components = "Alcohol"),
     list(components = c("FaceType", "Alcohol"))
   )
-  
+
   options$contrasts <- list(
     list(contrast = "none", variable = "FaceType"),
     list(contrast = "Helmert", variable = "Alcohol")
   )
   options$confidenceIntervalsContrast <- TRUE
-  
+
   options$postHocTestsVariables <- "Alcohol"
   options$postHocTestsBonferroni <- TRUE
   options$confidenceIntervalsPostHoc <- TRUE
   options$postHocTestsBootstrapping <- TRUE
   options$postHocTestsBootstrappingReplicates <- 500
-  
+
   options$marginalMeansTerms <- list(
     list(components = c("FaceType", "Alcohol"))
   )
   options$marginalMeansBootstrapping <- TRUE
   options$marginalMeansBootstrappingReplicates <- 500
-  options$marginalMeansCompareMainEffects <- FALSE 
+  options$marginalMeansCompareMainEffects <- FALSE
   set.seed(1)
   results <- jaspTools::runAnalysis("Anova", "Beer Goggles.csv", options)
-   
+
   table <- results[["results"]][["anovaContainer"]][["collection"]][["anovaContainer_anovaTable"]][["data"]]
   jaspTools::expect_equal_tables(table,
                       list("FaceType", 21.3333333333334, 1, 21.3333333333334, 15.5826086956522,
@@ -473,28 +473,28 @@ test_that("Field - Chapter 7 results match", {
                            "FaceType <unicode> Alcohol", 23.2916666666667, 2, 11.6458333333333,
                            8.50652173913045, 0.000791273868880283, "FALSE", "Residuals",
                            57.5, 42, 1.36904761904762, "", "", "TRUE"))
-  
+
   table <- results[["results"]]$anovaContainer$collection$anovaContainer_contrastContainer$collection[[1]]$collection[[1]]$data
   jaspTools::expect_equal_tables(table,
                       list("0 - 1, 2", -1.09375, 0.358257190138194, -3.05297431596026, 0.003921402019941,
                            42, -1.81674228032104, -0.37075771967896, "TRUE", "1 - 2", -0.6875,
                            0.413679770330811, -1.66191351211161, 0.103977316507, 42, -1.52233957533075,
                            0.147339575330745, "FALSE"))
-  
-  # removed both post hoc table and contrast table because bootstrap results are now in same table 
+
+  # removed both post hoc table and contrast table because bootstrap results are now in same table
   table <- results[["results"]]$anovaContainer$collection$anovaContainer_postHocContainer$collection[[1]]$collection$anovaContainer_postHocContainer_postHocStandardContainer_Alcohol$data
   jaspTools::expect_equal_tables(table,
                       list(0, 1, -0.769579725829725, -0.00376914898826841, 0.392000159227314,
-                           -1.48733254329573, 0.0548973391001531, 0.230950085511107, -1.8129965586672, 
+                           -1.48733254329573, 0.0548973391001531, 0.230950085511107, -1.8129965586672,
                            0.177726007657148, "TRUE", 0, 2, -1.43536324786325,
                            0.0142934574412497, 0.435378856593833, -2.31465226049576, -0.602581004497448, -3.47491007077881,
-                           0.00359956767679779, 0.00337043014651417, "FALSE", 1, 2, -0.690674603174602, 
+                           0.00359956767679779, 0.00337043014651417, "FALSE", 1, 2, -0.690674603174602,
                            0.018062606429518, 0.407611902363181, -1.43846891737073, 0.214248742598683, -1.66191351211161,
                            0.311931949521, 0.231712504393661, "FALSE"))
-  
+
 
   table <- results[["results"]]$anovaContainer$collection$anovaContainer_marginalMeansContainer$collection[[1]]$data
-  jaspTools::expect_equal_tables(table, 
+  jaspTools::expect_equal_tables(table,
                       list("TRUE", 0, 0, 0.609481794897967, -0.000576109837874483, 2.18310354552326,
                            3.5, 4.69446190218147, "FALSE", 0, 1, 0.319660323889613, -0.0167382728382766,
                            5.87621516465174, 6.33333333333334, 7.1687561775422, "TRUE",
@@ -504,5 +504,5 @@ test_that("Field - Chapter 7 results match", {
                            -0.0390126855170978, 6, 6.57142857142858, 7.5, "FALSE", 2, 1,
                            0.395829403830131, 0.0118089133089123, 5.4, 6.14285714285714,
                            7))
-  
+
 })

--- a/tests/testthat/test-anova.R
+++ b/tests/testthat/test-anova.R
@@ -349,6 +349,54 @@ test_that("Analysis handles errors", {
                   label="Negative WLS weights check")
 })
 
+options <- analysisOptions("Anova")
+options$contrasts <- list(list(contrast = "none", variable = "Species"))
+options$customContrasts <- list()
+options$dependent <- "Sepal.Length"
+options$fixedFactors <- "Species"
+options$modelTerms <- list(list(components = "Species"))
+options$postHocTestsVariables <- list(list(variable = "Species"))
+options$rainCloudPlotsHorizontalAxis <- ""
+options$rainCloudPlotsHorizontalDisplay <- FALSE
+options$rainCloudPlotsLabelYAxis <- ""
+options$rainCloudPlotsSeparatePlots <- ""
+
+# dataset is created from:
+# dd <- read.csv("~/github/jasp-desktop/Resources/Data Sets/Data Library/10. Machine Learning/iris.csv")
+# newLabels <- c("First species", "Second species", "Third species")
+# oldLabels <- unique(dd$Species)
+# dd$Species <- newLabels[match(dd$Species, oldLabels)]
+# dataset <- dd[c(1:5, 51:55, 101:105), ]
+dataset <- data.frame(
+   Sepal.Length = c(5.1, 4.9, 4.7, 4.6, 5, 7, 6.4, 6.9, 5.5, 6.5, 6.3, 5.8, 7.1, 6.3, 6.5),
+   Sepal.Width  = c(3.5, 3, 3.2, 3.1, 3.6, 3.2, 3.2, 3.1, 2.3, 2.8, 3.3, 2.7, 3, 2.9, 3),
+   Petal.Length = c(1.4, 1.4, 1.3, 1.5, 1.4, 4.7, 4.5, 4.9, 4, 4.6, 6, 5.1, 5.9, 5.6, 5.8),
+   Petal.Width  = c(0.2, 0.2, 0.2, 0.2, 0.2, 1.4, 1.5, 1.5, 1.3, 1.5, 2.5, 1.9, 2.1, 1.8, 2.2),
+   Species      = rep(c("First species", "Second species", "Third species"), each = 5)
+)
+
+set.seed(1)
+results <- runAnalysis("Anova", dataset, options)
+
+test_that("Post Hoc Comparisons - Species table results match and contrast names do not contain commas", {
+   table <- results[["results"]][["anovaContainer"]][["collection"]][["anovaContainer_postHocContainer"]][["collection"]][["anovaContainer_postHocContainer_postHocStandardContainer"]][["collection"]][["anovaContainer_postHocContainer_postHocStandardContainer_Species"]][["data"]]
+   jaspTools::expect_equal_tables(table,
+                                  list("TRUE", 0.286589136802729, "First species", "Second species",
+                                       -1.6, -5.58290526239083, 0.000324812090923943, "FALSE", 0.286589136802729,
+                                       "First species", "Third species", -1.54, -5.37354631505117,
+                                       0.000453440993214982, "FALSE", 0.286589136802729, "Second species",
+                                       "Third species", 0.0599999999999998, 0.209358947339655, 0.976174158311121
+                                  ))
+
+   # following https://github.com/jasp-stats/jasp-issues/issues/1295, assert that these names do not contain commas.
+   contrast_A <- vapply(table, `[[`, "contrast_A", FUN.VALUE = character(1L))
+   contrast_B <- vapply(table, `[[`, "contrast_B", FUN.VALUE = character(1L))
+   expect_true(!grepl(",", contrast_A))
+   expect_true(!grepl(",", contrast_B))
+
+})
+
+
 #### Andy Field Tests ----
 
 #### Chapter 4 -----


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-issues/issues/1295 and adds a unit test.

I took the liberty to also remove the trailing whitespace in the two files I touched. Diff without whitespace changes.

Here is a jasp file with the problem, upon refreshing the commas disappear:
(rename and drop .zip)
[iris.jasp.zip](https://github.com/jasp-stats/jaspAnova/files/6999545/iris.jasp.zip)
