### PR TITLE
Error on interaction effect with empty cell

### DIFF
--- a/R/commonAnovaBayesian.R
+++ b/R/commonAnovaBayesian.R
@@ -54,12 +54,21 @@
 
 .BANOVAerrorhandling <- function(dataset, options, analysisType) {
 
+  customChecks <- list()
+
   if (analysisType != "RM-ANOVA") {
     hasDV <- options$dependent != ""
     hasIV <- any(lengths(options[c("fixedFactors", "covariates")]) != 0)
     fixed <- options$fixedFactors
     noVariables <- !(hasDV && hasIV)
     target <- c(options$covariates, options$dependent)
+
+    # check if the last model has an interaction effect
+    mostComplexModel <- options[["modelTerms"]][[length(options[["modelTerms"]])]][["components"]]
+    mostComplexModel <- intersect(mostComplexModel, fixed)
+
+    if (length(mostComplexModel) > 1L)
+      customChecks[["missingInteractionCells"]] <- .BANOVAmissingInteractionCells
 
     if (!noVariables) {
       .hasErrors(
@@ -71,6 +80,9 @@
         observations.amount = paste("<", length(options$modelTerms) + 1),
         factorLevels.target = fixed,
         factorLevels.amount = " < 2",
+        # custom checks
+        custom              = customChecks,
+        missingInteractionCells.target = mostComplexModel,
         exitAnalysisIfErrors = TRUE
       )
     }
@@ -83,6 +95,13 @@
     noVariables <- !hasDV
     target <- c(covariates, fixed)
 
+    # check if the last model has an interaction effect
+    mostComplexModel <- options[["modelTerms"]][[length(options[["modelTerms"]])]][["components"]]
+    mostComplexModel <- intersect(mostComplexModel, fixed)
+
+    if (length(mostComplexModel) > 1L)
+      customChecks[["missingInteractionCells"]] <- .BANOVAmissingInteractionCells
+
     if (length(target) > 0L) {
       .hasErrors(
         dataset = dataset,
@@ -94,6 +113,9 @@
         factorLevels.target = fixed,
         factorLevels.amount = " < 2",
         duplicateColumns.target = target,
+        # custom checks
+        custom              = customChecks,
+        missingInteractionCells.target = mostComplexModel,
         exitAnalysisIfErrors = TRUE
       )
     }
@@ -158,6 +180,42 @@
   }
 
   return(list(noVariables = noVariables, hasIV = hasIV, hasDV = hasDV))
+}
+
+.BANOVAmissingInteractionCells <- function(dataset, target) {
+
+  # sorts a data frame by all its columns
+  sortDataFrame <- function(df) {
+    df[do.call(order, df), ]
+  }
+
+  uniqueObservedCombinations <- sortDataFrame(unique(dataset[, target, drop = FALSE]))
+  uniqueExpectedCombinations <- sortDataFrame(do.call(expand.grid, c(lapply(uniqueObservedCombinations, unique), stringsAsFactors = FALSE)))
+
+  # if the rows match then it must be
+  if (nrow(uniqueObservedCombinations) == nrow(uniqueExpectedCombinations))
+    return(NULL)
+
+  # find missing combinations
+  observedStrings <- unname(apply(uniqueObservedCombinations, 1L, paste, collapse = jaspBase::interactionSymbol))
+  expectedStrings <- unname(apply(uniqueExpectedCombinations, 1L, paste, collapse = jaspBase::interactionSymbol))
+  missingStrings  <- setdiff(expectedStrings, observedStrings)
+  missingStringsCollapsed <- paste(missingStrings[1:10], collapse = ", ")
+
+  interactionVariable <- paste(colnames(uniqueObservedCombinations), collapse = jaspBase::interactionSymbol)
+
+  if (length(missingStrings) <= 10) {
+    return(gettextf(
+      "The interaction effect of %1$s has no observations for the combination(s): %2$s. Please adjust the model and remove any interactions with missing cells",
+      interactionVariable, missingStringsCollapsed
+    ))
+  } else {
+    return(gettextf(
+      "The interaction effect of %1$s has no observations for the combination(s): %2$s. Only the first 10 missing combinations are shown. Please adjust the model and remove any interactions with missing cells",
+      interactionVariable, missingStringsCollapsed
+    ))
+  }
+
 }
 
 # model comparison ----

--- a/R/commonAnovaBayesian.R
+++ b/R/commonAnovaBayesian.R
@@ -64,8 +64,11 @@
     target <- c(options$covariates, options$dependent)
 
     # check if the last model has an interaction effect
-    mostComplexModel <- options[["modelTerms"]][[length(options[["modelTerms"]])]][["components"]]
-    mostComplexModel <- intersect(mostComplexModel, fixed)
+    mostComplexModel <- NULL
+    if (length(options[["modelTerms"]]) > 0L) {
+      mostComplexModel <- options[["modelTerms"]][[length(options[["modelTerms"]])]][["components"]]
+      mostComplexModel <- intersect(mostComplexModel, fixed)
+    }
 
     if (length(mostComplexModel) > 1L)
       customChecks[["missingInteractionCells"]] <- .BANOVAmissingInteractionCells
@@ -96,8 +99,11 @@
     target <- c(covariates, fixed)
 
     # check if the last model has an interaction effect
-    mostComplexModel <- options[["modelTerms"]][[length(options[["modelTerms"]])]][["components"]]
-    mostComplexModel <- intersect(mostComplexModel, fixed)
+    mostComplexModel <- NULL
+    if (length(options[["modelTerms"]]) > 0L) {
+      mostComplexModel <- options[["modelTerms"]][[length(options[["modelTerms"]])]][["components"]]
+      mostComplexModel <- intersect(mostComplexModel, fixed)
+    }
 
     if (length(mostComplexModel) > 1L)
       customChecks[["missingInteractionCells"]] <- .BANOVAmissingInteractionCells

--- a/R/commonAnovaBayesian.R
+++ b/R/commonAnovaBayesian.R
@@ -200,7 +200,7 @@
   observedStrings <- unname(apply(uniqueObservedCombinations, 1L, paste, collapse = jaspBase::interactionSymbol))
   expectedStrings <- unname(apply(uniqueExpectedCombinations, 1L, paste, collapse = jaspBase::interactionSymbol))
   missingStrings  <- setdiff(expectedStrings, observedStrings)
-  missingStringsCollapsed <- paste(missingStrings[1:10], collapse = ", ")
+  missingStringsCollapsed <- paste(missingStrings[1:min(length(missingStrings), 10)], collapse = ", ")
 
   interactionVariable <- paste(colnames(uniqueObservedCombinations), collapse = jaspBase::interactionSymbol)
 

--- a/tests/testthat/test-anovabayesian.R
+++ b/tests/testthat/test-anovabayesian.R
@@ -148,4 +148,11 @@ test_that("Analysis handles errors", {
   options$modelTerms <- list(list(components="facFive", isNuisance=FALSE))
   results <- jaspTools::runAnalysis("AnovaBayesian", "test.csv", options)
   expect_true(results[["results"]][["error"]], label = "Too few obs check")
+
+  options$dependent <- "contGamma"
+  options$fixedFactors <- c("facFive", "facFifty")
+  options$modelTerms <- list(list(components=c("facFive", "facFifty")))
+  results <- jaspTools::runAnalysis("AnovaBayesian", "test.csv", options)
+  expect_true(results[["results"]][["error"]], label = "Missing interaction cells check")
+
 })

--- a/tests/testthat/test-anovarepeatedmeasuresbayesian.R
+++ b/tests/testthat/test-anovarepeatedmeasuresbayesian.R
@@ -356,3 +356,23 @@ test_that("Model Comparison table results matches for beer data", {
          2.56126043451803e-29, 7.66536860710751e-29, "Null model (incl. subject)",
          0.25, 2.55512286903585e-29, 10.5326335209382))
 })
+
+options <- initOpts()
+options$repeatedMeasuresCells <- c("contNormal", "contGamma")
+options$repeatedMeasuresFactors <- list(
+  list(levels=c("Level 1", "Level 2"), name="RM_FACTOR_1")
+)
+options$betweenSubjectFactors <- c("facGender", "facFifty")
+options$covariates <- "contcor1"
+options$modelTerms <- list(
+  list(components="RM_FACTOR_1", isNuisance=TRUE),
+  list(components="facGender", isNuisance=FALSE),
+  list(components="contcor1", isNuisance=FALSE),
+  list(components=c("RM_FACTOR_1", "facGender", "facFifty"), isNuisance=FALSE)
+)
+set.seed(1)
+results <- jaspTools::runAnalysis("AnovaRepeatedMeasuresBayesian", "test.csv", options)
+test_that("Missing cells in interactions with between-subject factors returns an error") {
+  expect_true(results[["results"]][["error"]], label = "Missing interaction cells check")
+}
+

--- a/tests/testthat/test-anovarepeatedmeasuresbayesian.R
+++ b/tests/testthat/test-anovarepeatedmeasuresbayesian.R
@@ -372,7 +372,7 @@ options$modelTerms <- list(
 )
 set.seed(1)
 results <- jaspTools::runAnalysis("AnovaRepeatedMeasuresBayesian", "test.csv", options)
-test_that("Missing cells in interactions with between-subject factors returns an error") {
+test_that("Missing cells in interactions with between-subject factors returns an error", {
   expect_true(results[["results"]][["error"]], label = "Missing interaction cells check")
-}
+})
 


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-test-release/issues/1375

New behavior:

![image](https://user-images.githubusercontent.com/21319932/130049993-1615cb1d-6bd8-4da3-8848-4ea592b77cfa.png)

Note that you'll have to rename the module to e.g., `jaspAnovass` otherwise the old one might still be reloaded.

Also does this for the between-subjects effects of the Bayesian RM-ANOVA and adds a unit test.