### PR TITLE
Bayesian RM ANOVA: Add dependency on Repeated Measures Cells to effects table

### DIFF
--- a/R/commonAnovaBayesian.R
+++ b/R/commonAnovaBayesian.R
@@ -498,7 +498,8 @@
   effectsTable$position <- 2
   effectsTable$dependOn(c(
     "effects", "effectsType", "dependent", "randomFactors", "priorFixedEffects", "priorRandomEffects",
-    "sampleModeNumAcc", "fixedNumAcc", "bayesFactorType", "modelTerms", "fixedFactors", "seed", "setSeed"
+    "sampleModeNumAcc", "fixedNumAcc", "bayesFactorType", "modelTerms", "fixedFactors", "seed", "setSeed",
+    "repeatedMeasuresCells"
   ))
 
   effectsTable$addCitation(.BANOVAcitations[1:2])


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-test-release/issues/1362

I used this jasp file to test the issue.

[BugsBANOVA_state_issue.jasp.zip](https://github.com/jasp-stats/jaspAnova/files/7060468/BugsBANOVA_state_issue.jasp.zip)
(rename and drop .zip)

The effects table did not depend on `repeatedMeasuresCells`, so if you swapped these the analysis refreshed but that one table always stayed the same :sweat: 