### PR TITLE
Add GORIC(A) to AN(C)OVA and RM ANOVA

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,7 +27,8 @@ Imports:
   onewaytests,
   plyr,
   stringi,
-  stringr
+  stringr,
+  restriktor
 Remotes:
   jasp-stats/jaspBase,
   jasp-stats/jaspDescriptives,

--- a/R/ancova.R
+++ b/R/ancova.R
@@ -870,13 +870,13 @@ Ancova <- function(jaspResults, dataset = NULL, options) {
   coefNames <- names(coef(fit))
   terms     <- strsplit(coefNames, ":")
 
-  for (i in 1:length(xLevels)) {
+  for (i in seq_along(xLevels)) {
     idxFac  <- which(stringr::str_detect(coefNames, names(xLevels)[i]))
     lvls    <- if (options[["includeIntercept"]]) xLevels[[i]][-1] else xLevels[[i]]
     newLvls <- numeric(length(idxFac))
     newLvls[1:length(idxFac)] <- lvls
 
-    for (j in 1:length(idxFac)) {
+    for (j in seq_along(idxFac)) {
       idxInt <- which(stringr::str_detect(terms[[idxFac[j]]], names(xLevels)[i]))
       terms[[idxFac[j]]][idxInt] <- paste0(names(xLevels)[i], newLvls[j])
     }
@@ -934,6 +934,7 @@ Ancova <- function(jaspResults, dataset = NULL, options) {
   modelHasErrors <- vapply(modelList, isTryError, logical(1))
 
   if (any(modelHasErrors)) {
+
     syntaxErrors   <- sapply(modelList[modelHasErrors], function(msg) {
 
       msgSplit      <- stringr::str_split(msg, "lavaan ERROR: ")
@@ -1063,13 +1064,13 @@ Ancova <- function(jaspResults, dataset = NULL, options) {
   if (compareAgainst != "unconstrained")
     coefs    <- rbind(coefs, coef(compareGoric[["model.org"]]))
 
-  for (i in 1:length(xLevels)) {
+  for (i in seq_along(xLevels)) {
     idxFac  <- which(stringr::str_detect(coefNames, names(xLevels)[i]))
     idxLvl  <- if (includeIntercept || i > 1) 1:(length(xLevels[[i]])-1) else 1:length(xLevels[[i]])
     newLvls <- numeric(length(idxFac))
     newLvls[1:length(idxFac)] <- idxLvl
 
-    for (j in 1:length(idxFac)) {
+    for (j in seq_along(idxFac)) {
       idxInt <- which(stringr::str_detect(terms[[idxFac[j]]], names(xLevels)[i]))
 
       terms[[idxFac[j]]][idxInt] <- paste0(names(xLevels)[i], " (", newLvls[j], ")")
@@ -1314,13 +1315,13 @@ Ancova <- function(jaspResults, dataset = NULL, options) {
   coefNames <- names(coef(baseModelRefit))
   terms     <- strsplit(coefNames, ":")
 
-  for (i in 1:length(xLevels)) {
+  for (i in seq_along(xLevels)) {
     idxFac  <- which(stringr::str_detect(coefNames, names(xLevels)[i]))
     lvls    <- xLevels[[i]][-1]
     newLvls <- numeric(length(idxFac))
     newLvls[1:length(idxFac)] <- lvls
 
-    for (j in 1:length(idxFac)) {
+    for (j in seq_along(idxFac)) {
       idxInt <- which(stringr::str_detect(terms[[idxFac[j]]], names(xLevels)[i]))
       terms[[idxFac[j]]][idxInt] <- paste0(names(xLevels)[i], newLvls[j])
     }

--- a/R/ancova.R
+++ b/R/ancova.R
@@ -1134,6 +1134,7 @@ Ancova <- function(jaspResults, dataset = NULL, options) {
       newVcov <- restriktor:::sandwich(newModel,
                                       bread. = restriktor:::bread.conLM(newModel),
                                       meat.  = restriktor:::meatHC(newModel, type = options[["restrictedModelHeteroskedasticity"]]))
+
     newEmmObj <- emmeans::qdrg(
       formula = formula(newModel[["model.org"]]),
       data    = newModel[["model.org"]][["model"]],
@@ -1252,10 +1253,11 @@ Ancova <- function(jaspResults, dataset = NULL, options) {
     complementState  <- createJaspState()
     modelSummaryContainer[["Complement"]] <- complementState
     goricObj <- container[["modelComparison"]]$object
+
     complementEmmObj <- emmeans::qdrg(
       formula = baseModel[["modelFormula"]],
       data    = baseModel[["fit"]][["model"]],
-      coef    = coef(goricObj)[which(row.names(coef(goricObj)) == "complement"),],
+      coef    = as.numeric(coef(goricObj)[row.names(coef(goricObj)) == "complement",]),
       vcov    = vcov(baseModel[["fit"]]),
       df      = baseModel[["fit"]][["df.residual"]]
     )
@@ -1340,7 +1342,7 @@ Ancova <- function(jaspResults, dataset = NULL, options) {
     emmObj <- emmeans::qdrg(
       formula = formula(baseModel),
       data    = resamples,
-      coef    = coef(newGoricObj)[which(row.names(coef(newGoricObj)) == "complement"),],
+      coef    = as.numeric(coef(newGoricObj)[row.names(coef(newGoricObj)) == "complement",]),
       vcov    = vcov(baseModel),
       df      = baseModel[["df.residual"]]
     )

--- a/R/ancova.R
+++ b/R/ancova.R
@@ -902,7 +902,7 @@ Ancova <- function(jaspResults, dataset = NULL, options) {
 
   new.names <- encodeColNames(usedvars)
 
-  for (i in 1:length(usedvars)) {
+  for (i in seq_along(usedvars)) {
     syntax <- try(gsub(usedvars[i], new.names[i], syntax))
   }
 
@@ -938,9 +938,10 @@ Ancova <- function(jaspResults, dataset = NULL, options) {
 
       msgSplit      <- stringr::str_split(msg, "lavaan ERROR: ")
       msgExtracted  <- msgSplit[[1]][length(msgSplit[[1]])]
-      msgUpper      <- paste0(toupper(substr(msgExtracted, 1, 1)), substr(msgExtracted, 2, nchar(msgExtracted)), ".")
+      msgExtracted  <- gsub("\n", "", msgExtracted)
+      msgFinal      <- gettextf("Syntax error: %1$s%2$s.", toupper(substr(msgExtracted, 1, 1)), substr(msgExtracted, 2, nchar(msgExtracted)))
 
-      return(msgUpper)
+      return(msgFinal)
     })
 
     finMsg <- paste(unlist(syntaxErrors), collapse = "\n")
@@ -999,12 +1000,11 @@ Ancova <- function(jaspResults, dataset = NULL, options) {
 }
 
 .ordinalRestrictionsComparisonTableFill <- function(comparisonTable, compareGoric, modelNames, comparison, reference, type) {
-  if (comparison == "unconstrained")
-    nms <- c(modelNames, gettext("Unconstrained"))
-  else if (comparison == "complement")
-    nms <- c(modelNames, gettext("Complement"))
-  else
-    nms <- modelNames
+  nms <- switch(comparison,
+                unconstrained = c(modelNames, gettext("Unconstrained")),
+                complement    = c(modelNames, gettext("Complement")),
+                modelNames
+                )
 
   compareDf <- compareGoric[["result"]]
   compareDf[["model"]] <- nms
@@ -1076,7 +1076,7 @@ Ancova <- function(jaspResults, dataset = NULL, options) {
     }
   }
 
-  coefNamesPretty  <- sapply(terms, paste, collapse = " \u273B ")
+  coefNamesPretty  <- sapply(terms, paste, collapse = jaspBase::interactionSymbol)
   coefNamesPrettyV <- decodeColNames(coefNamesPretty)
   coefDf           <- cbind.data.frame(coef = coefNamesPrettyV, t(coefs), stringsAsFactors = FALSE)
 

--- a/R/ancova.R
+++ b/R/ancova.R
@@ -1531,7 +1531,7 @@ Ancova <- function(jaspResults, dataset = NULL, options) {
       if (isTryError(newSummaryObj)) {
         newSummaryTable$setError(.extractErrorMessage(newSummaryObj))
         next
-      } else if (isBoot && any(is.na(newSummaryObj[["lower.CL"]]) || is.na(newSummaryObj[["upper.CL"]]))) {
+      } else if (isBoot && any(is.na(newSummaryObj[["lower.CL"]]) | is.na(newSummaryObj[["upper.CL"]]))) {
         newSummaryTable$addFootnote(message = gettext("Some confidence intervals could not be computed. Possibly too few successful bootstrap replicates."))
       }
       for (i in 1:(length(names(newSummaryObj)) - 5)) {
@@ -1612,6 +1612,11 @@ Ancova <- function(jaspResults, dataset = NULL, options) {
       plotDf <- newModelSummary
     else
       plotDf <- rbind(plotDf, newModelSummary)
+  }
+
+  if(options[["restrictedConfidenceIntervalBootstrap"]] &&
+     any(is.na(plotDf[["lower.CL"]]) | is.na(plotDf[["upper.CL"]]))) {
+    stop(gettext("Some confidence intervals could not be computed. Possibly too few successful bootstrap replicates."))
   }
 
   if (!is.null(factors) && !is.null(levels)) {

--- a/inst/help/goric/restriktorSyntax.md
+++ b/inst/help/goric/restriktorSyntax.md
@@ -1,0 +1,82 @@
+Syntax for Creating Order Restrictions
+===
+
+### Order Restrictions
+A special syntax is necessary to specify order restrictions in the General Linear Model. Order restrictions mean that effects in a model are required to be equal or unequal. For example, when performing an ANOVA with three groups, the following order constraint could be applied:
+
+&mu;<sub>Low</sub> < &mu;<sub>Med</sub> < &mu;<sub>High</sub>.
+
+This is an example for an *inequality constraint* and restricts the mean of the first group to be smaller than the mean of the second group, which must be smaller than the mean of the third group. The null-model for the ANOVA could also be expressed as an *equality constraint*:
+
+&mu;<sub>Low</sub> = &mu;<sub>Med</sub> = &mu;<sub>High</sub>,
+
+which means that all three groups must have the same mean.
+
+### Basic Syntax
+To specify an order constraint, the (in-) equality between two coefficients must be expressed using `==`, `<`, or `>` operators. Coefficients can be accessed by their name in the data set. For instance:  
+
+`variable1 == variable2`,  
+
+indicates that the coefficient (effect) for `variable1` is equal to the coefficient for `variable2`. Coefficients can also be constrained to a constant, e.g., `variable1 == 0`.
+
+#### Factors
+Factor variables can have several coeffcients (usually k-1, with k being the number of levels). They can be accessed by the factor variable name immediately followed by the respective level:  
+
+`factorLow == factorHigh`.  
+
+#### Intercept
+The intercept can be accessed using `.Intercept.`.
+
+#### Example
+If dummy coding was used, the syntax for the inequality constraint shown in the beginning could look like:  
+
+`.Intercept. < .Intercept. + factorMed`  
+`.Intercept. + factorMed < .Intercept. + factorHigh`.  
+
+The constraint is split up in relations between two coefficients and each relation is written on a new line. Alternatively, they can also be put on the same line and separated with a semicolon (i.e., `;`).
+The above equality constraint could be simplified as:  
+
+`factor2 == 0; factor3 == 0`,  
+
+which means that level `Med` and `High` do not differ from level `Low` (the intercept).
+
+### Advanced Syntax
+#### Interactions
+Constraints on interaction effects can be specified using `variable1.variable2` to refer to an interaction term between `variable1` and `variable2`.
+
+#### Defining New Parameters
+New parameters can be defined as a function of the existing parameters in the model using the `:=` (assign) operator. For example, a constraint on the difference between two factor levels could be specified as:  
+
+`diff := factorMed - factorHigh`  
+`diff > 0`.
+
+#### Repeated Measures
+Constraints on coefficients of within-subject factors can be specified similar to between-subject factors, e.g.:
+
+`withinLevel1 == withinLevel2`.  
+
+Note that there is no intercept in the model when only within-subject factors are included. If two interacting within-subject factors are specified, only their interaction coefficients can be accessed, e.g.:
+
+`within1Level1.within2Level1 == within1Level2.within2Level2`.  
+
+Here `within1Level1 == within2Level2` would result in an error. If both within- and between-subjects terms are in the model, their coefficients can also only be accessed through interactions:
+
+`betweenLevel2.withinLevel1 == betweenLevel2.withinLevel2`.  
+
+Note that between-subject terms always have to be specified before within-subject terms. The first level of between subject factors is the intercept and can be accessed as `.Intercept.`:
+
+`.Intercept..withinLevel1 == .Intercept..withinLevel2`.
+
+``
+
+### Summary
+The syntax for specifying order constraints contains the following elements:
+- `==` for equality constraints
+- `<` and `>` for inequality constraints
+- `.Intercept.` to access the intercept
+- `variable1.variable2` to access interaction terms
+- `:=` to define new parameters
+- Interaction syntax if both within- and between-subject terms are included
+
+### Examples
+For further information and examples, see: https://restriktor.org/tutorial/syntax.html

--- a/inst/qml/Ancova.qml
+++ b/inst/qml/Ancova.qml
@@ -136,6 +136,11 @@ Form
 		}
 	}
 	
+	ANOVA.OrderRestrictions
+	{
+		type: "Ancova"
+	}
+	
 	Section
 	{
 		title: qsTr("Post Hoc Tests")

--- a/inst/qml/Anova.qml
+++ b/inst/qml/Anova.qml
@@ -110,6 +110,11 @@ Form
 		}
 	}
 	
+	ANOVA.OrderRestrictions
+	{
+		type: "Anova"
+	}
+	
 	Section
 	{
 		title: qsTr("Post Hoc Tests")

--- a/inst/qml/AnovaRepeatedMeasures.qml
+++ b/inst/qml/AnovaRepeatedMeasures.qml
@@ -142,6 +142,11 @@ Form
 		}
 	}
 
+	ANOVA.OrderRestrictions
+	{
+		type: "RM-Anova"
+	}
+	
 	Section
 	{
 		title: qsTr("Post Hoc Tests")

--- a/inst/qml/common/OrderRestrictions.qml
+++ b/inst/qml/common/OrderRestrictions.qml
@@ -1,0 +1,258 @@
+//
+// Copyright (C) 2013-2018 University of Amsterdam
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public
+// License along with this program.  If not, see
+// <http://www.gnu.org/licenses/>.
+//
+
+import QtQuick			2.12
+import JASP.Controls	1.0
+import JASP.Widgets		1.0
+import JASP				1.0
+
+Section
+{
+	property var type
+	
+	title: qsTr("Order Restrictions")
+	columns: 1
+	
+	Text
+	{
+		text: qsTr("Place each restriction on a new line. For example:\n\nfactorLow = factorMed = factorHigh\nfactorLow < factorMed < factorHigh\n\nwhere factor is the factor name and Low/Med/High are the factor level names.")
+	}
+	
+	Form
+	{
+		TabView
+		{
+			id: models
+			name: "restrictedModels"
+			maximumItems: 8
+			newItemName: qsTr("Model 1")
+			optionKey: "modelName"
+			
+			content: Group 
+			{
+				TextArea
+				{
+					name: "restrictionSyntax"
+					width: models.width
+					textType: JASP.TextTypeModel
+					trim: true
+					applyScriptInfo: qsTr("Ctrl + Enter to apply. Click on the blue button below for help on the restriction syntax")
+				}
+				
+				Group
+				{
+					columns: 2
+					
+					Group
+					{
+						columns: 1
+						
+						CheckBox
+						{
+							name: "modelSummary"
+							label: qsTr("Summary for ") + rowValue
+							checked: false
+						}
+						
+						CheckBox
+						{
+							name: "informedHypothesisTest"
+							label: qsTr("Informed hypothesis test for ") + rowValue
+							checked: false
+							visible: type !== "RM-Anova"
+							columns: 3
+							
+							CheckBox
+							{
+								name: "informedHypothesisTestGlobal"
+								label: qsTr("Type global")
+							}
+							
+							CheckBox
+							{
+								name: "informedHypothesisTestA"
+								label: qsTr("Type A")
+							}
+							
+							CheckBox
+							{
+								name: "informedHypothesisTestB"
+								label: qsTr("Type B")
+								checked: true
+							}
+						}
+					}
+					
+					HelpButton
+					{
+						toolTip: qsTr("Click to learn more about the syntax for order restrictions.")
+						helpPage: "goric/restriktorSyntax"
+					}
+				}
+			}
+		}
+	}
+	
+	CheckBox
+	{
+		name: "includeIntercept"
+		id: incInt
+		label: qsTr("Include intercept")
+		visible: type !== "RM-Anova"
+		checked: true
+	}
+	
+	Group
+	{
+		title: qsTr("Model comparison")
+		columns: 1
+		
+		DropDown
+		{
+			property var comparisonValuesInclComplement: 
+			[
+				{ label: qsTr("Complement"), value: "complement"},
+				{ label: qsTr("Unconstrained"), value: "unconstrained" },
+				{ label: qsTr("None"), value: "none" }
+			]
+			property var comparisonValuesExclComplement: 
+			[
+				{ label: qsTr("Unconstrained"), value: "unconstrained" },
+				{ label: qsTr("None"), value: "none" }
+			]
+			property var comparisonValues: (models.count > 1) ? comparisonValuesExclComplement : comparisonValuesInclComplement
+			
+			name: "restrictedModelComparison"
+			label: qsTr("Compare against")
+			indexDefaultValue: 0
+			values: comparisonValues
+			id: modelComparison
+		}
+		
+		DropDown
+		{
+			property var modelsToReference: (modelComparison.value === "none") ? [] : [ modelComparison.currentLabel ]
+			
+			name: "restrictedModelComparisonReference"
+			label: qsTr("Reference model for weight ratios")
+			indexDefaultValue: 0
+			source:  [ models, { values: modelsToReference } ]
+		}
+		
+		CheckBox
+		{
+			name: "restrictedModelComparisonCoefficients"
+			label: qsTr("Show model coefficients")
+			childrenOnSameRow: true
+			
+			CheckBox
+			{
+				name: "highlightEstimates"
+				label: qsTr("Highlight coefficients")
+				checked: true
+			}
+		}
+	}
+	
+	Group
+	{
+		title: qsTr("Uncertainty")
+		columns: 1
+		
+		Group
+		{
+			columns: 2
+			
+			CIField
+			{
+				name: "restrictedConfidenceIntervalLevel"
+				afterLabel: type === "RM-Anova" ? qsTr("% confidence intervals based on") : qsTr("% confidence intervals")
+			}
+			
+			Group
+			{
+				columns: 2
+				
+				CheckBox
+				{
+					name: "restrictedConfidenceIntervalBootstrap"
+					label: qsTr("based on")
+					id: restrictedModelsBootstrap
+					visible: type !== "RM-Anova"
+				}
+				
+				IntegerField
+				{
+					name: "restrictedConfidenceIntervalBootstrapSamples"
+					defaultValue: 1000
+					afterLabel: qsTr("bootstraps")
+				}
+			}
+		}
+		
+		DropDown
+		{
+			name: "restrictedModelHeteroskedasticity"
+			label: qsTr("Huber-White correction for heteroskedasticity")
+			indexDefaultValue: 0
+			visible: type !== "RM-Anova"
+			enabled: !restrictedModelsBootstrap.checked
+			values:
+			[
+				{ label: qsTr("None"), value: "none" },
+				{ label: qsTr("HC0"), value: "HC0" },
+				{ label: qsTr("HC1"), value: "HC1" },
+				{ label: qsTr("HC2"), value: "HC2" },
+				{ label: qsTr("HC3"), value: "HC3" },
+				{ label: qsTr("HC4"), value: "HC4" },
+				{ label: qsTr("HC4m"), value: "HC4m" },
+				{ label: qsTr("HC5"), value: "HC5" },
+			]
+		}
+	}
+	
+	VariablesForm
+	{
+		preferredHeight: jaspTheme.smallDefaultVariablesFormHeight * 0.5
+		AvailableVariablesList
+		{
+			name: "restrictedModelTerms"
+			title: qsTr("Model Terms")
+			source: (type === "Ancova" ? [ { name: "modelTerms", discard: "covariates" } ] :
+										 type === "RM-Anova" ? [ { name: "betweenModelTerms", discard: "covariates" }, { name: "withinModelTerms" } ] :
+															   "modelTerms")
+		}
+		
+		AssignedVariablesList { name: "restrictedModelMarginalMeansTerm"; title: qsTr("Restricted Marginal Means"); singleVariable: true }
+	}
+	
+	VariablesForm
+	{
+		preferredHeight: jaspTheme.smallDefaultVariablesFormHeight * 0.5
+		AvailableVariablesList
+		{
+			property var modelsToPlot: (modelComparison.value === "none") ? [] : [ modelComparison.currentLabel ]
+			
+			name: "availableRestrictedModels"
+			title: qsTr("Restricted Models")
+			source: [ models, { values: modelsToPlot }]
+		}
+		
+		AssignedVariablesList { name: "plotRestrictedModels"; title: qsTr("Plot Restricted Marginal Means") }
+	}
+}

--- a/tests/testthat/test-ancova.R
+++ b/tests/testthat/test-ancova.R
@@ -130,6 +130,186 @@ test_that("Contrasts table results match", {
   }
 })
 
+# Order restrictions
+
+test_that("Model Comparison Table results match", {
+  options <- jaspTools::analysisOptions("Ancova")
+  options$dependent <- "contNormal"
+  options$fixedFactors <- "facFive"
+  options$covariates <- "contGamma"
+  options$modelTerms <- list(list(components = "facFive"),
+                            list(components = "contGamma"))
+  options$restrictedModels <- list(list(restrictionSyntax = "facFive2 == facFive3", modelName = "Model 1", 
+                                        modelSummary = FALSE, informedHypothesisTest = FALSE))
+  options$includeIntercept <- TRUE
+  options$restrictedModelComparisonCoefficients <- FALSE
+  options$highlightEstimates <- FALSE
+
+  comparison <- c("none", "complement", "unconstrained")
+
+  refTables <- list(none = list(301.817283957095, 1, -144.908641978547, "Model 1", 6, 1),
+                    complement = list(301.817283957095, 0.727394455051185, -144.908641978547, "Model 1",
+                                      6, 1, 303.780170056147, 0.272605544948815, -144.890085028074,
+                                      "Complement", 7, 0.374769896932514),
+                    unconstrained = list(301.817283957095, 0.727394455051185, -144.908641978547, "Model 1",
+                                         6, 1, 303.780170056147, 0.272605544948815, -144.890085028074,
+                                         "Unconstrained", 7, 0.374769896932514)
+  )
+
+  for (comp in comparison) {
+    options$restrictedModelComparison <- comp
+    options$restrictedModelComparisonReference <- "Model 1"
+    results <- jaspTools::runAnalysis("Ancova", "test.csv", options)
+    table <- results[["results"]][["anovaContainer"]][["collection"]][["anovaContainer_ordinalRestrictions"]][["collection"]][["anovaContainer_ordinalRestrictions_comparisonTable"]][["data"]]
+    jaspTools::expect_equal_tables(table, refTables[[comp]])
+  }
+})
+
+test_that("Model Coefficients Table results match", {
+  options <- jaspTools::analysisOptions("Ancova")
+  options$dependent <- "contNormal"
+  options$fixedFactors <- "facFive"
+  options$covariates <- "contGamma"
+  options$modelTerms <- list(list(components = "facFive"),
+                            list(components = "contGamma"))
+  options$restrictedModels <- list(list(restrictionSyntax = "facFive2 == facFive3", modelName = "Model 1", 
+      modelSummary = FALSE, informedHypothesisTest = FALSE))
+  options$includeIntercept <- TRUE
+  options$restrictedModelComparisonCoefficients <- TRUE
+  options$highlightEstimates <- TRUE
+
+  comparison <- c("none", "complement", "unconstrained")
+
+  refTables <- list(none = list(0, -0.154738134097615, "(Intercept)", -0.149125688998174, 0, -0.169197472317935,
+                                "facFive (1)", -0.136596626658275, 0, -0.169197472317935, "facFive (2)",
+                                -0.200720248979633, 0, 0.327083593303366, "facFive (3)", 0.326355030521639,
+                                0, -0.163871391497433, "facFive (4)", -0.163006179525351, 0,
+                                -0.0167295176108609, "contGamma", -0.0194902423183439),
+                    complement = list(0, -0.154738134097615, "(Intercept)", -0.149125688998174, -0.149125688998174,
+                                      0, -0.169197472317935, "facFive (1)", -0.136596626658275, -0.136596626658275,
+                                      0, -0.169197472317935, "facFive (2)", -0.200720248979633, -0.200720248979633,
+                                      0, 0.327083593303366, "facFive (3)", 0.326355030521639, 0.326355030521639,
+                                      0, -0.163871391497433, "facFive (4)", -0.163006179525351, -0.163006179525351,
+                                      0, -0.0167295176108609, "contGamma", -0.0194902423183439, -0.0194902423183439),
+                    unconstrained = list(0, -0.154738134097615, "(Intercept)", -0.149125688998174, 0, -0.169197472317935,
+                                         "facFive (1)", -0.136596626658275, 0, -0.169197472317935, "facFive (2)",
+                                         -0.200720248979633, 0, 0.327083593303366, "facFive (3)", 0.326355030521639,
+                                         0, -0.163871391497433, "facFive (4)", -0.163006179525351, 0,
+                                         -0.0167295176108609, "contGamma", -0.0194902423183439)
+  )
+
+  for (comp in comparison) {
+    options$restrictedModelComparison <- comp
+    options$restrictedModelComparisonReference <- "Model 1"
+    results <- jaspTools::runAnalysis("Ancova", "test.csv", options)
+    table <- results[["results"]][["anovaContainer"]][["collection"]][["anovaContainer_ordinalRestrictions"]][["collection"]][["anovaContainer_ordinalRestrictions_coefficientsTable"]][["data"]]
+    jaspTools::expect_equal_tables(table, refTables[[comp]])
+  }
+})
+
+test_that("Model Summary Tables results match", {
+  options <- jaspTools::analysisOptions("Ancova")
+  options$dependent <- "contNormal"
+  options$fixedFactors <- "facFive"
+  options$covariates <- "contGamma"
+  options$modelTerms <- list(list(components = "facFive"),
+                             list(components = "contGamma"))
+  options$restrictedModels <- list(list(restrictionSyntax = "facFive2 == facFive3", modelName = "Model 1", 
+      modelSummary = TRUE, informedHypothesisTest = FALSE))
+  options$includeIntercept <- TRUE
+  options$restrictedModelComparison <- "complement"
+  options$restrictedModelComparisonReference <- "Complement"
+  options$restrictedModelComparisonCoefficients <- FALSE
+  options$highlightEstimates <- FALSE
+  options$restrictedModelHeteroskedasticity <- "none"
+  options$restrictedModelMarginalMeansTerm <- "facFive"
+  options$restrictedConfidenceIntervalLevel <- 0.95
+  options$restrictedConfidenceIntervalBootstrap <- FALSE
+  options$restrictedConfidenceIntervalBootstrapSamples <- 100
+  set.seed(1)
+  results <- jaspTools::runAnalysis("Ancova", "test.csv", options)
+
+  table <- results[["results"]][["anovaContainer"]][["collection"]][["anovaContainer_ordinalRestrictions"]][["collection"]][["anovaContainer_ordinalRestrictions_modelSummaryTables"]][["collection"]][["anovaContainer_ordinalRestrictions_modelSummaryTables_Model 1"]][["data"]]
+  jaspTools::expect_equal_tables(table,
+    list(0.167755327188213, 1, -0.691028194488133, -0.357946059857934,
+       -0.0248639252277356, 0.167755327188215, 2, -0.691028194488137,
+       -0.357946059857934, -0.0248639252277325, 0.237172321281224,
+       3, -0.332576197902421, 0.138335005763366, 0.609246209429153,
+       0.237473181443956, 4, -0.82412854760905, -0.352619979037433,
+       0.118888589534183, 0.238474666193202, 5, -0.487062884727979,
+       -0.0135658447100634, 0.459931195307852))
+
+  table <- results[["results"]][["anovaContainer"]][["collection"]][["anovaContainer_ordinalRestrictions"]][["collection"]][["anovaContainer_ordinalRestrictions_modelSummaryTables"]][["collection"]][["anovaContainer_ordinalRestrictions_modelSummaryTables_Complement"]][["data"]]
+  jaspTools::expect_equal_tables(table,
+    list(0.159726533626395, 1, -0.651051263991961, -0.325345214198275,
+       0.0483008940136666, 0.199148441441157, 2, -0.750097437911133,
+       -0.389468836519633, -0.0353077560310458, 0.255662534264972,
+       3, -0.691415077431805, 0.137606442981639, 0.581202803702893,
+       0.229407103860898, 4, -0.873806534090684, -0.351754767065351,
+       0.0280912707956404, 0.287368435064222, 5, -0.632138106089154,
+       -0.0147805628983806, 0.521517824174558))
+})
+
+test_that("Model Summary Tables results match (bootstrap)", {
+  options <- jaspTools::analysisOptions("Ancova")
+  options$dependent <- "contNormal"
+  options$fixedFactors <- "facFive"
+  options$covariates <- "contGamma"
+  options$modelTerms <- list(list(components = "facFive"),
+                             list(components = "contGamma"))
+  options$restrictedModels <- list(list(restrictionSyntax = "facFive2 == facFive3", modelName = "Model 1", 
+      modelSummary = TRUE, informedHypothesisTest = FALSE))
+  options$includeIntercept <- TRUE
+  options$restrictedModelComparison <- "complement"
+  options$restrictedModelComparisonReference <- "Complement"
+  options$restrictedModelComparisonCoefficients <- FALSE
+  options$highlightEstimates <- FALSE
+  options$restrictedModelHeteroskedasticity <- "none"
+  options$restrictedModelMarginalMeansTerm <- "facFive"
+  options$restrictedConfidenceIntervalLevel <- 0.95
+  options$restrictedConfidenceIntervalBootstrap <- TRUE
+  options$restrictedConfidenceIntervalBootstrapSamples <- 100
+  set.seed(1)
+  results <- jaspTools::runAnalysis("Ancova", "test.csv", options)
+
+  table <- results[["results"]][["anovaContainer"]][["collection"]][["anovaContainer_ordinalRestrictions"]][["collection"]][["anovaContainer_ordinalRestrictions_modelSummaryTables"]][["collection"]][["anovaContainer_ordinalRestrictions_modelSummaryTables_Model 1"]][["data"]]
+  jaspTools::expect_equal_tables(table,
+    list(0.136444548762599, 1, -0.596749619547702, -0.357946059857934,
+       -0.075006510897505, 0.136444548762599, 2, -0.596749619547702,
+       -0.357946059857934, -0.075006510897505, 0.255829822339125, 3,
+       -0.683329961210056, 0.138335005763366, 0.593206544372537, 0.229114370339469,
+       4, -0.872325989888679, -0.352619979037433, 0.0262324605079643,
+       0.286896913993928, 5, -0.631396953717359, -0.0135658447100634,
+       0.526191083889959))
+})
+
+test_that("Restricted Marginal Means Plot matches", {
+  options <- jaspTools::analysisOptions("Ancova")
+  options$dependent <- "contNormal"
+  options$fixedFactors <- "facFive"
+  options$covariates <- "contGamma"
+  options$modelTerms <- list(list(components = "facFive"),
+                             list(components = "contGamma"))
+  options$restrictedModels <- list(list(restrictionSyntax = "facFive2 == facFive3", modelName = "Model 1", 
+      modelSummary = TRUE, informedHypothesisTest = FALSE))
+  options$includeIntercept <- TRUE
+  options$restrictedModelComparison <- "complement"
+  options$restrictedModelComparisonReference <- "Complement"
+  options$restrictedModelComparisonCoefficients <- FALSE
+  options$highlightEstimates <- FALSE
+  options$restrictedConfidenceIntervalLevel <- 0.95
+  options$restrictedConfidenceIntervalBootstrap <- FALSE
+  options$restrictedConfidenceIntervalBootstrapSamples <- 100
+  options$restrictedModelHeteroskedasticity <- "none"
+  options$restrictedModelMarginalMeansTerm <- "facFive"
+  options$plotRestrictedModels <- c("Model 1", "Complement")
+  set.seed(1)
+  results <- jaspTools::runAnalysis("Ancova", "test.csv", options)
+  plotName <- results[["results"]][["anovaContainer"]][["collection"]][["anovaContainer_ordinalRestrictions"]][["collection"]][["anovaContainer_ordinalRestrictions_marginalMeansPlotContainer"]][["collection"]][["anovaContainer_ordinalRestrictions_marginalMeansPlotContainer_marginalMeansPlotSingle"]][["data"]]
+  testPlot <- results[["state"]][["figures"]][[plotName]][["obj"]]
+  jaspTools::expect_equal_plots(testPlot, "restricted-marginal-means")
+})
+
 test_that("Post Hoc table results match", {
   options <- jaspTools::analysisOptions("Ancova")
   options$dependent <- "contNormal"

--- a/tests/testthat/test-anova.R
+++ b/tests/testthat/test-anova.R
@@ -130,6 +130,248 @@ test_that("Contrasts table results match", {
   }
 })
 
+# Order restrictions
+
+test_that("Model Comparison Table results match", {
+  options <- jaspTools::analysisOptions("Anova")
+  options$dependent <- "contNormal"
+  options$fixedFactors <- "facFive"
+  options$modelTerms <- list(list(components = "facFive"))
+  options$restrictedModels <- list(list(restrictionSyntax = "facFive2 == facFive3", modelName = "Model 1", 
+      modelSummary = FALSE, informedHypothesisTest = FALSE))
+  options$includeIntercept <- TRUE
+  options$restrictedModelComparisonCoefficients <- FALSE
+  options$highlightEstimates <- FALSE
+
+  comparison <- c("none", "complement", "unconstrained")
+
+  refTables <- list(none = list(299.876218374723, 1, -144.938109187361, "Model 1", 5, 1),
+                    complement = list(299.876218374723, 0.729151752769625, -144.938109187361, "Model 1",
+                                       5, 1, 301.85686474531, 0.270848247230375, -144.928432372655,
+                                       "Complement", 6, 0.371456622303355),
+                    unconstrained = list(299.876218374723, 0.729151752769625, -144.938109187361, "Model 1",
+                                         5, 1, 301.85686474531, 0.270848247230375, -144.928432372655,
+                                         "Unconstrained", 6, 0.371456622303355)
+  )
+
+  for (comp in comparison) {
+    options$restrictedModelComparison <- comp
+    options$restrictedModelComparisonReference <- "Model 1"
+    results <- jaspTools::runAnalysis("Anova", "test.csv", options)
+    table <- results[["results"]][["anovaContainer"]][["collection"]][["anovaContainer_ordinalRestrictions"]][["collection"]][["anovaContainer_ordinalRestrictions_comparisonTable"]][["data"]]
+    jaspTools::expect_equal_tables(table, refTables[[comp]])
+  }
+})
+
+test_that("Model Coefficients Table results match", {
+  options <- jaspTools::analysisOptions("Anova")
+  options$dependent <- "contNormal"
+  options$fixedFactors <- "facFive"
+  options$modelTerms <- list(list(components = "facFive"))
+  options$restrictedModels <- list(list(restrictionSyntax = "facFive2 == facFive3", modelName = "Model 1", 
+      modelSummary = FALSE, informedHypothesisTest = FALSE))
+  options$includeIntercept <- TRUE
+  options$restrictedModelComparisonCoefficients <- TRUE
+  options$highlightEstimates <- TRUE
+
+  comparison <- c("none", "complement", "unconstrained")
+
+  refTables <- list(none = list(-0.18874858754, "(Intercept)", -0.18874858754, 0, -0.17246392881,
+                                "facFive (1)", -0.149788723010001, 0, -0.17246392881, "facFive (2)",
+                                -0.19513913461, 0.33149855864, "facFive (3)", 0.33149855864,
+                                -0.16911442746, "facFive (4)", -0.16911442746),
+                    complement = list(-0.18874858754, "(Intercept)", -0.18874858754, -0.18874858754,
+                                      0, -0.17246392881, "facFive (1)", -0.149788723010001, -0.149788723010001,
+                                      0, -0.17246392881, "facFive (2)", -0.19513913461, -0.19513913461,
+                                      0.33149855864, "facFive (3)", 0.33149855864, 0.33149855864,
+                                      -0.16911442746, "facFive (4)", -0.16911442746, -0.16911442746),
+                    unconstrained = list(-0.18874858754, "(Intercept)", -0.18874858754, 0, -0.17246392881,
+                                         "facFive (1)", -0.149788723010001, 0, -0.17246392881, "facFive (2)",
+                                         -0.19513913461, 0.33149855864, "facFive (3)", 0.33149855864,
+                                         -0.16911442746, "facFive (4)", -0.16911442746)
+  )
+
+  for (comp in comparison) {
+    options$restrictedModelComparison <- comp
+    options$restrictedModelComparisonReference <- "Model 1"
+    results <- jaspTools::runAnalysis("Anova", "test.csv", options)
+    table <- results[["results"]][["anovaContainer"]][["collection"]][["anovaContainer_ordinalRestrictions"]][["collection"]][["anovaContainer_ordinalRestrictions_coefficientsTable"]][["data"]]
+    jaspTools::expect_equal_tables(table, refTables[[comp]])
+  }
+})
+
+test_that("Model Summary Tables results match", {
+  options <- jaspTools::analysisOptions("Anova")
+  options$dependent <- "contNormal"
+  options$fixedFactors <- "facFive"
+  options$modelTerms <- list(list(components = "facFive"))
+  options$restrictedModels <- list(list(restrictionSyntax = "facFive2 == facFive3", modelName = "Model 1", 
+      modelSummary = TRUE, informedHypothesisTest = FALSE))
+  options$includeIntercept <- TRUE
+  options$restrictedModelComparison <- "complement"
+  options$restrictedModelComparisonReference <- "Complement"
+  options$restrictedModelComparisonCoefficients <- FALSE
+  options$highlightEstimates <- FALSE
+  options$restrictedModelHeteroskedasticity <- "none"
+  options$restrictedModelMarginalMeansTerm <- "facFive"
+  options$restrictedConfidenceIntervalLevel <- 0.95
+  options$restrictedConfidenceIntervalBootstrap <- FALSE
+  options$restrictedConfidenceIntervalBootstrapSamples <- 100
+  set.seed(1)
+  results <- jaspTools::runAnalysis("Anova", "test.csv", options)
+
+  table <- results[["results"]][["anovaContainer"]][["collection"]][["anovaContainer_ordinalRestrictions"]][["collection"]][["anovaContainer_ordinalRestrictions_modelSummaryTables"]][["collection"]][["anovaContainer_ordinalRestrictions_modelSummaryTables_Model 1"]][["data"]]
+  jaspTools::expect_equal_tables(table,
+    list(0.166362494250772, 1, -0.691483825007023, -0.36121251635, -0.0309412076929767,
+       0.166362494250772, 2, -0.691483825007023, -0.36121251635, -0.0309412076929769,
+       0.235272095639658, 3, -0.324324192865472, 0.1427499711, 0.609824135065473,
+       0.235272095639658, 4, -0.824937178965473, -0.357863015, 0.109211148965473,
+       0.235272095639658, 5, -0.473279025065472, -0.00620486109999993,
+       0.460869302865473))
+
+  table <- results[["results"]][["anovaContainer"]][["collection"]][["anovaContainer_ordinalRestrictions"]][["collection"]][["anovaContainer_ordinalRestrictions_modelSummaryTables"]][["collection"]][["anovaContainer_ordinalRestrictions_modelSummaryTables_Complement"]][["data"]]
+  jaspTools::expect_equal_tables(table,
+    list(0.152881329939938, 1, -0.64388018755408, -0.338537310550001, -0.00354379466403432,
+       0.192169660443263, 2, -0.758505931989504, -0.38388772215, -0.0116615107877175,
+       0.255248521349526, 3, -0.54994009460931, 0.1427499711, 0.648064239566305,
+       0.221213425775123, 4, -0.869736239522443, -0.357863015, 0.0670782536979813,
+       0.287877496012916, 5, -0.634812151493361, -0.00620486110000035,
+       0.579110209876577))
+})
+
+test_that("Model Summary Tables results match (bootstrap)", {
+  options <- jaspTools::analysisOptions("Anova")
+  options$dependent <- "contNormal"
+  options$fixedFactors <- "facFive"
+  options$modelTerms <- list(list(components = "facFive"))
+  options$restrictedModels <- list(list(restrictionSyntax = "facFive2 == facFive3", modelName = "Model 1", 
+      modelSummary = TRUE, informedHypothesisTest = FALSE))
+  options$includeIntercept <- TRUE
+  options$restrictedModelComparison <- "complement"
+  options$restrictedModelComparisonReference <- "Complement"
+  options$restrictedModelComparisonCoefficients <- FALSE
+  options$highlightEstimates <- FALSE
+  options$restrictedModelHeteroskedasticity <- "none"
+  options$restrictedModelMarginalMeansTerm <- "facFive"
+  options$restrictedConfidenceIntervalLevel <- 0.95
+  options$restrictedConfidenceIntervalBootstrap <- TRUE
+  options$restrictedConfidenceIntervalBootstrapSamples <- 100
+  set.seed(1)
+  results <- jaspTools::runAnalysis("Anova", "test.csv", options)
+
+  table <- results[["results"]][["anovaContainer"]][["collection"]][["anovaContainer_ordinalRestrictions"]][["collection"]][["anovaContainer_ordinalRestrictions_modelSummaryTables"]][["collection"]][["anovaContainer_ordinalRestrictions_modelSummaryTables_Model 1"]][["data"]]
+  jaspTools::expect_equal_tables(table,
+    list(0.132159439299099, 1, -0.580876057728091, -0.36121251635, -0.0663723194372581,
+        0.132159439299099, 2, -0.580876057728091, -0.36121251635, -0.0663723194372581,
+        0.255248521349526, 3, -0.54994009460931, 0.1427499711, 0.648064239566305,
+        0.221213425775123, 4, -0.869736239522443, -0.357863015, 0.0670782536979812,
+        0.287877496012916, 5, -0.634812151493361, -0.00620486109999993,
+        0.579110209876577))
+})
+
+test_that("Informed Hypothesis Tables results match (equality restriction)", {
+  options <- jaspTools::analysisOptions("Anova")
+  options$dependent <- "contNormal"
+  options$fixedFactors <- "facFive"
+  options$modelTerms <- list(list(components = "facFive"))
+  options$restrictedModels <- list(list(restrictionSyntax = "facFive2 == facFive3", modelName = "Model 1", 
+      modelSummary = TRUE, informedHypothesisTest = TRUE, informedHypothesisTestGlobal = TRUE, 
+      informedHypothesisTestA = FALSE, informedHypothesisTestB = FALSE))
+  options$includeIntercept <- TRUE
+  options$restrictedModelComparison <- "complement"
+  options$restrictedModelComparisonReference <- "Complement"
+  options$restrictedModelComparisonCoefficients <- FALSE
+  options$highlightEstimates <- FALSE
+  options$restrictedConfidenceIntervalBootstrap <- FALSE
+  options$restrictedModelHeteroskedasticity <- "none"
+
+  results <- jaspTools::runAnalysis("Anova", "test.csv", options)
+
+  # Test table
+  table <- results[["results"]][["anovaContainer"]][["collection"]][["anovaContainer_ordinalRestrictions"]][["collection"]][["anovaContainer_ordinalRestrictions_informedHypothesisTests"]][["collection"]][["anovaContainer_ordinalRestrictions_informedHypothesisTests_Model 1"]][["collection"]][["anovaContainer_ordinalRestrictions_informedHypothesisTests_Model 1_classical"]][["data"]]
+  jaspTools::expect_equal_tables(table,
+    list(1, 95, 0.892423350599015, 0.0183877272312399))
+
+  # Constraint table
+  table <- results[["results"]][["anovaContainer"]][["collection"]][["anovaContainer_ordinalRestrictions"]][["collection"]][["anovaContainer_ordinalRestrictions_informedHypothesisTests"]][["collection"]][["anovaContainer_ordinalRestrictions_informedHypothesisTests_Model 1"]][["collection"]][["anovaContainer_ordinalRestrictions_informedHypothesisTests_Model 1_constraintTable"]][["data"]]
+  jaspTools::expect_equal_tables(table,
+    list("facFive2 = facFive3"))
+
+  # Reduction summary table
+  table <- results[["results"]][["anovaContainer"]][["collection"]][["anovaContainer_ordinalRestrictions"]][["collection"]][["anovaContainer_ordinalRestrictions_informedHypothesisTests"]][["collection"]][["anovaContainer_ordinalRestrictions_informedHypothesisTests_Model 1"]][["collection"]][["anovaContainer_ordinalRestrictions_informedHypothesisTests_Model 1_reductionTable"]][["data"]]
+  jaspTools::expect_equal_tables(table,
+    list(0.041712010479224, 0.041897456039623))
+})
+
+test_that("Informed Hypothesis Tables results match (inequality restriction)", {
+  options <- jaspTools::analysisOptions("Anova")
+  options$dependent <- "contNormal"
+  options$fixedFactors <- "facFive"
+  options$modelTerms <- list(list(components = "facFive"))
+  options$restrictedModels <- list(list(restrictionSyntax = "facFive2 < facFive3", modelName = "Model 1", 
+      modelSummary = TRUE, informedHypothesisTest = TRUE, informedHypothesisTestGlobal = TRUE, 
+      informedHypothesisTestA = TRUE, informedHypothesisTestB = TRUE))
+  options$includeIntercept <- TRUE
+  options$restrictedModelComparison <- "complement"
+  options$restrictedModelComparisonReference <- "Complement"
+  options$restrictedModelComparisonCoefficients <- FALSE
+  options$highlightEstimates <- FALSE
+  options$restrictedConfidenceIntervalBootstrap <- FALSE
+  options$restrictedModelHeteroskedasticity <- "none"
+
+  results <- jaspTools::runAnalysis("Anova", "test.csv", options)
+
+  # Test type A table
+  table <- results[["results"]][["anovaContainer"]][["collection"]][["anovaContainer_ordinalRestrictions"]][["collection"]][["anovaContainer_ordinalRestrictions_informedHypothesisTests"]][["collection"]][["anovaContainer_ordinalRestrictions_informedHypothesisTests_Model 1"]][["collection"]][["anovaContainer_ordinalRestrictions_informedHypothesisTests_Model 1_A"]][["data"]]
+  jaspTools::expect_equal_tables(table,
+    list(1, 95, 1, 0))
+
+  # Text type B table
+  table <- results[["results"]][["anovaContainer"]][["collection"]][["anovaContainer_ordinalRestrictions"]][["collection"]][["anovaContainer_ordinalRestrictions_informedHypothesisTests"]][["collection"]][["anovaContainer_ordinalRestrictions_informedHypothesisTests_Model 1"]][["collection"]][["anovaContainer_ordinalRestrictions_informedHypothesisTests_Model 1_B"]][["data"]]
+  jaspTools::expect_equal_tables(table,
+    list(1, 95, 0.446211675299507, 0.0183877272312399))
+
+  # Test type global table
+  table <- results[["results"]][["anovaContainer"]][["collection"]][["anovaContainer_ordinalRestrictions"]][["collection"]][["anovaContainer_ordinalRestrictions_informedHypothesisTests"]][["collection"]][["anovaContainer_ordinalRestrictions_informedHypothesisTests_Model 1"]][["collection"]][["anovaContainer_ordinalRestrictions_informedHypothesisTests_Model 1_global"]][["data"]]
+  jaspTools::expect_equal_tables(table,
+    list(1, 95, 0.323962094057912, 4.13592576338067))
+
+  # Constraint table
+  table <- results[["results"]][["anovaContainer"]][["collection"]][["anovaContainer_ordinalRestrictions"]][["collection"]][["anovaContainer_ordinalRestrictions_informedHypothesisTests"]][["collection"]][["anovaContainer_ordinalRestrictions_informedHypothesisTests_Model 1"]][["collection"]][["anovaContainer_ordinalRestrictions_informedHypothesisTests_Model 1_constraintTable"]][["data"]]
+  jaspTools::expect_equal_tables(table,
+    list("facFive2 &lt; facFive3"))
+
+  # Reduction summary table
+  table <- results[["results"]][["anovaContainer"]][["collection"]][["anovaContainer_ordinalRestrictions"]][["collection"]][["anovaContainer_ordinalRestrictions_informedHypothesisTests"]][["collection"]][["anovaContainer_ordinalRestrictions_informedHypothesisTests_Model 1"]][["collection"]][["anovaContainer_ordinalRestrictions_informedHypothesisTests_Model 1_reductionTable"]][["data"]]
+  jaspTools::expect_equal_tables(table,
+    list(0.041712010479224, 0.041897456039623))
+})
+
+test_that("Restricted Marginal Means Plot matches", {
+  options <- jaspTools::analysisOptions("Anova")
+  options$dependent <- "contNormal"
+  options$fixedFactors <- "facFive"
+  options$modelTerms <- list(list(components = "facFive"))
+  options$restrictedModels <- list(list(restrictionSyntax = "facFive2 == facFive3", modelName = "Model 1", 
+      modelSummary = TRUE, informedHypothesisTest = FALSE))
+  options$includeIntercept <- TRUE
+  options$restrictedModelComparison <- "complement"
+  options$restrictedModelComparisonReference <- "Complement"
+  options$restrictedModelComparisonCoefficients <- FALSE
+  options$highlightEstimates <- FALSE
+  options$restrictedConfidenceIntervalLevel <- 0.95
+  options$restrictedConfidenceIntervalBootstrap <- FALSE
+  options$restrictedConfidenceIntervalBootstrapSamples <- 100
+  options$restrictedModelHeteroskedasticity <- "none"
+  options$restrictedModelMarginalMeansTerm <- "facFive"
+  options$plotRestrictedModels <- c("Model 1", "Complement")
+  set.seed(1)
+  results <- jaspTools::runAnalysis("Anova", "test.csv", options)
+  plotName <- results[["results"]][["anovaContainer"]][["collection"]][["anovaContainer_ordinalRestrictions"]][["collection"]][["anovaContainer_ordinalRestrictions_marginalMeansPlotContainer"]][["collection"]][["anovaContainer_ordinalRestrictions_marginalMeansPlotContainer_marginalMeansPlotSingle"]][["data"]]
+  testPlot <- results[["state"]][["figures"]][[plotName]][["obj"]]
+  jaspTools::expect_equal_plots(testPlot, "restricted-marginal-means")
+})
+
 test_that("Post Hoc table results match", {
   options <- jaspTools::analysisOptions("Anova")
   options$dependent <- "contNormal"

--- a/tests/testthat/test-anovarepeatedmeasures.R
+++ b/tests/testthat/test-anovarepeatedmeasures.R
@@ -314,6 +314,140 @@ test_that("Analysis handles errors", {
 
 })
 
+# Order restrictions
+
+test_that("Model Comparison Table results match", {
+  options <- initOpts()
+  options$restrictedModels <- list(list(restrictionSyntax = "DrinkBeer.ImageryPositive == DrinkBeer.ImageryNegative", modelName = "Model 1", 
+      modelSummary = FALSE))
+  options$restrictedModelComparisonCoefficients <- FALSE
+  options$highlightEstimates <- FALSE
+
+  comparison <- c("none", "complement", "unconstrained")
+
+  refTables <- list(none = list(65.3787953763916, 1, -24.6893976881958, "Model 1", 8, 1),
+                    complement = list(65.3787953763916, 5.38204349406708e-06, -24.6893976881958, "Model 1",
+                                      8, 1, 41.1139212919128, 0.999994617956506, -11.5569606459564,
+                                      "Complement", 9, 185802.032082954),
+                    unconstrained = list(65.3787953763916, 5.38204349406708e-06, -24.6893976881958, "Model 1",
+                                        8, 1, 41.1139212919128, 0.999994617956506, -11.5569606459564,
+                                        "Unconstrained", 9, 185802.032082954)
+  )
+
+  for (comp in comparison) {
+    options$restrictedModelComparison <- comp
+    options$restrictedModelComparisonReference <- "Model 1"
+    results <- jaspTools::runAnalysis(name = "AnovaRepeatedMeasures", dataset = "AnovaRepeatedMeasures.csv",
+                                      options = options)
+    table <- results[["results"]][["rmAnovaContainer"]][["collection"]][["rmAnovaContainer_ordinalRestrictions"]][["collection"]][["rmAnovaContainer_ordinalRestrictions_comparisonTable"]][["data"]]
+    jaspTools::expect_equal_tables(table, refTables[[comp]])
+  }
+})
+
+test_that("Model Coefficients Table results match", {
+  options <- initOpts()
+  options$restrictedModels <- list(list(restrictionSyntax = "DrinkBeer.ImageryPositive == DrinkBeer.ImageryNegative", modelName = "Model 1", 
+      modelSummary = FALSE))
+  options$restrictedModelComparisonCoefficients <- TRUE
+  options$highlightEstimates <- TRUE
+
+  comparison <- c("none", "complement", "unconstrained")
+
+  refTables <- list(none = list(0, 17.9005468044547, "Drink (1) <unicode><unicode><unicode> Imagery (3)",
+                                21.05, 0, 15.4086987057289, "Drink (1) <unicode><unicode><unicode> Imagery (2)",
+                                10, 0, 17.9005468044547, "Drink (1) <unicode><unicode><unicode> Imagery (1)",
+                                4.45, 0, 22.1697351259155, "Drink (3) <unicode><unicode><unicode> Imagery (3)",
+                                25.35, 0, 7.04823417277014, "Drink (3) <unicode><unicode><unicode> Imagery (2)",
+                                11.65, 0, -7.85291461824021, "Drink (3) <unicode><unicode><unicode> Imagery (1)",
+                                -12, 0, 15.9668405738938, "Drink (2) <unicode><unicode><unicode> Imagery (3)",
+                                17.4, 0, -1.75877897060299, "Drink (2) <unicode><unicode><unicode> Imagery (2)",
+                                2.35, 0, -8.63956054981439, "Drink (2) <unicode><unicode><unicode> Imagery (1)",
+                                -9.2),
+                    complement = list(0, 17.9005468044547, "Drink (1) <unicode><unicode><unicode> Imagery (3)",
+                                      21.05, 21.05, 0, 15.4086987057289, "Drink (1) <unicode><unicode><unicode> Imagery (2)",
+                                      10, 10, 0, 17.9005468044547, "Drink (1) <unicode><unicode><unicode> Imagery (1)",
+                                      4.45, 4.45, 0, 22.1697351259155, "Drink (3) <unicode><unicode><unicode> Imagery (3)",
+                                      25.35, 25.35, 0, 7.04823417277014, "Drink (3) <unicode><unicode><unicode> Imagery (2)",
+                                      11.65, 11.65, 0, -7.85291461824021, "Drink (3) <unicode><unicode><unicode> Imagery (1)",
+                                      -12, -12, 0, 15.9668405738938, "Drink (2) <unicode><unicode><unicode> Imagery (3)",
+                                      17.4, 17.4, 0, -1.75877897060299, "Drink (2) <unicode><unicode><unicode> Imagery (2)",
+                                      2.35, 2.35, 0, -8.63956054981439, "Drink (2) <unicode><unicode><unicode> Imagery (1)",
+                                      -9.2, -9.2),
+                    unconstrained = list(0, 17.9005468044547, "Drink (1) <unicode><unicode><unicode> Imagery (3)",
+                                          21.05, 0, 15.4086987057289, "Drink (1) <unicode><unicode><unicode> Imagery (2)",
+                                          10, 0, 17.9005468044547, "Drink (1) <unicode><unicode><unicode> Imagery (1)",
+                                          4.45, 0, 22.1697351259155, "Drink (3) <unicode><unicode><unicode> Imagery (3)",
+                                          25.35, 0, 7.04823417277014, "Drink (3) <unicode><unicode><unicode> Imagery (2)",
+                                          11.65, 0, -7.85291461824021, "Drink (3) <unicode><unicode><unicode> Imagery (1)",
+                                          -12, 0, 15.9668405738938, "Drink (2) <unicode><unicode><unicode> Imagery (3)",
+                                          17.4, 0, -1.75877897060299, "Drink (2) <unicode><unicode><unicode> Imagery (2)",
+                                          2.35, 0, -8.63956054981439, "Drink (2) <unicode><unicode><unicode> Imagery (1)",
+                                          -9.2)
+  )
+
+  for (comp in comparison) {
+    options$restrictedModelComparison <- comp
+    options$restrictedModelComparisonReference <- "Model 1"
+    results <- jaspTools::runAnalysis(name = "AnovaRepeatedMeasures",
+                            dataset = "AnovaRepeatedMeasures.csv", options = options)
+    table <- results[["results"]][["rmAnovaContainer"]][["collection"]][["rmAnovaContainer_ordinalRestrictions"]][["collection"]][["rmAnovaContainer_ordinalRestrictions_coefficientsTable"]][["data"]]
+    jaspTools::expect_equal_tables(table, refTables[[comp]])
+  }
+})
+
+test_that("Model Summary Tables results match (bootstrap)", {
+  options <- jaspTools::analysisOptions("AnovaRepeatedMeasures")
+  options$withinModelTerms <- list(list(components = "Within"))
+  options$repeatedMeasuresFactors <- list(list(name = "Within", levels = c("Pre", "Post")))
+  options$repeatedMeasuresCells <- c("contNormal", "contGamma")
+  options$restrictedModels <- list(list(restrictionSyntax = "WithinPre < WithinPost", modelName = "Model 1", 
+      modelSummary = TRUE))
+  options$restrictedModelComparison <- "complement"
+  options$restrictedModelComparisonReference <- "Complement"
+  options$restrictedModelComparisonCoefficients <- FALSE
+  options$highlightEstimates <- FALSE
+  options$restrictedModelMarginalMeansTerm <- list(list(variable = "Within"))
+  options$restrictedConfidenceIntervalLevel <- 0.95
+  options$restrictedConfidenceIntervalBootstrapSamples <- 100
+  options$restrictedConfidenceIntervalBootstrap <- TRUE
+  set.seed(1)
+  results <- jaspTools::runAnalysis("AnovaRepeatedMeasures", "test.csv", options)
+
+  table <- results[["results"]][["rmAnovaContainer"]][["collection"]][["rmAnovaContainer_ordinalRestrictions"]][["collection"]][["rmAnovaContainer_ordinalRestrictions_modelSummaryTables"]][["collection"]][["rmAnovaContainer_ordinalRestrictions_modelSummaryTables_Complement"]][["data"]]
+  jaspTools::expect_equal_tables(table,
+    list(0.146702302423307, "Pre", 0.321926740266315, 0.54943666426025,
+       0.877499836681278, 0.146702302423307, "Post", 0.321926740266315,
+       0.54943666426025, 0.877499836681278))
+
+  table <- results[["results"]][["rmAnovaContainer"]][["collection"]][["rmAnovaContainer_ordinalRestrictions"]][["collection"]][["rmAnovaContainer_ordinalRestrictions_modelSummaryTables"]][["collection"]][["rmAnovaContainer_ordinalRestrictions_modelSummaryTables_Model 1"]][["data"]]
+  jaspTools::expect_equal_tables(table,
+    list(0.102194914765997, "Pre", -0.395106865411576, -0.18874858754,
+       0.0341948803983838, 0.160856272417964, "Post", 1.65979037329036,
+       2.03296079621, 2.28644677007259))
+})
+
+test_that("Restricted Marginal Means Plot matches", {
+  options <- jaspTools::analysisOptions("AnovaRepeatedMeasures")
+  options$withinModelTerms <- list(list(components = "Within"))
+  options$repeatedMeasuresFactors <- list(list(name = "Within", levels = c("Pre", "Post")))
+  options$repeatedMeasuresCells <- c("contNormal", "contGamma")
+  options$restrictedModels <- list(list(restrictionSyntax = "WithinPre < WithinPost", modelName = "Model 1", 
+      modelSummary = TRUE))
+  options$restrictedModelComparison <- "complement"
+  options$restrictedModelComparisonReference <- "Complement"
+  options$restrictedModelComparisonCoefficients <- FALSE
+  options$highlightEstimates <- FALSE
+  options$restrictedModelMarginalMeansTerm <- list(list(variable = "Within"))
+  options$restrictedConfidenceIntervalLevel <- 0.95
+  options$restrictedConfidenceIntervalBootstrapSamples <- 100
+  options$restrictedConfidenceIntervalBootstrap <- TRUE
+  options$plotRestrictedModels <- c("Model 1", "Complement")
+  set.seed(1)
+  results <- jaspTools::runAnalysis("AnovaRepeatedMeasures", "test.csv", options)
+  plotName <- results[["results"]][["rmAnovaContainer"]][["collection"]][["rmAnovaContainer_ordinalRestrictions"]][["collection"]][["rmAnovaContainer_ordinalRestrictions_marginalMeansPlotContainer"]][["collection"]][["rmAnovaContainer_ordinalRestrictions_marginalMeansPlotContainer_marginalMeansPlotSingle"]][["data"]]
+  testPlot <- results[["state"]][["figures"]][[plotName]][["obj"]]
+  jaspTools::expect_equal_plots(testPlot, "restricted-marginal-means")
+})
 
 # Mixed Effects
 initOpts <- function(){


### PR DESCRIPTION
Copy of PR by @maltelueken: https://github.com/jasp-stats/jaspAnova/pull/72 with my code review suggestions implemented by me.

There is a lot of happening with encoding/decoding the restriction syntax, would be good to instead solve it directly in QML. Doing that now seems error prone though, and since this feature is having a priority for this release, not sure whether we have time to fix that systematically 😕 

I also tried to tinker with it in JASP, I had some trouble to get it going as installing the `restriktor` package always failed, not sure why. In the end I managed to test it out a little, it seems to work, but we should obviously test it much more before the release. 

Let me know @vandenman @FBartos if you are able to take a look or whether I should assign someone else.