### PR TITLE
Gorica fixes

### DIFF
--- a/R/ancova.R
+++ b/R/ancova.R
@@ -1414,7 +1414,7 @@ Ancova <- function(jaspResults, dataset = NULL, options) {
             newTest <- ihtObject[[type]]
 
             newTestTable <- createJaspTable(paste0(gettext("Test Type "), type))
-            newTestTable$addColumnInfo(name = "stat", title = gettext("F\u0305"), type = "number")
+            newTestTable$addColumnInfo(name = "stat", title = gettext("F"), type = "number")
             newTestTable$addColumnInfo(name = "df", title = gettext("df"), type = "integer")
             newTestTable$addColumnInfo(name = "dfresid", title = gettext("Residual df"), type = "integer")
             newTestTable$addColumnInfo(name = "pval", title = gettext("p"), type = "pvalue")

--- a/R/ancova.R
+++ b/R/ancova.R
@@ -911,6 +911,19 @@ Ancova <- function(jaspResults, dataset = NULL, options) {
       }
     }
   }
+
+  # check duplication of order restrictions
+  for (model in restrictedModels) {
+    lines <- strsplit(model[["restrictionSyntax"]], "\n")[[1]]
+    lines <- trimws(lines)
+    lines <- gsub(" ", "", lines)
+    lines <- lines[lines != ""]
+
+    if(length(lines) != length(unique(lines))) {
+      ordinalRestrictionsContainer$setError(gettextf("Syntax error found in model %1$s.\n\nSome restrictions are duplicate!", model[["modelName"]]))
+      return()
+    }
+  }
 }
 # the following two functions should not be necessary if the QML component
 # for the restrictions encodes the column names

--- a/R/ancova.R
+++ b/R/ancova.R
@@ -987,7 +987,7 @@ Ancova <- function(jaspResults, dataset = NULL, options) {
                        goric = gettext("GORIC = Generalized Order-Restricted Information Criterion (Kuiper, Hoijtink, & Silvapulle, 2011)."),
                                gettext("GORICA = Generalized Order-Restricted Information Criterion Approximation.")
                        )
-  comparisonTable$addFootnote(gettextf("Ratios indicate the relative weight for each model against the %1$s model %2$s. %3$s", comparison, reference, abbrev))
+  comparisonTable$addFootnote(gettextf('Ratios indicate the relative weight for each model against the "%1$s" model. %2$s', reference, abbrev))
   comparisonTable$addCitation(c("Kuiper, R. M., Hoijtink, H., Silvapulle, M. J. (2011). An Akaike-type information criterion for model selection under equality constarints. Biometrika, 98(2), 495-501.",
                                 "Vanbrabant, L., Van Loey, N., & Kuiper, R. M. (2020). Evaluating a theory-based hypothesis against its complement using an AIC-type information criterion with an application to facial burn injury. Psychological Methods, 25(2), 129-142."))
 

--- a/R/ancova.R
+++ b/R/ancova.R
@@ -805,7 +805,7 @@ Ancova <- function(jaspResults, dataset = NULL, options) {
     ordinalRestrictionsContainer <- createJaspContainer(title = gettext("Order Restrictions"), dependencies = "restrictedModels")
     anovaContainer[["ordinalRestrictions"]] <- ordinalRestrictionsContainer
   } else {
-    orginalRestrictionsContainer <- anovaContainer[["ordinalRestrictions"]]
+    ordinalRestrictionsContainer <- anovaContainer[["ordinalRestrictions"]]
   }
 
   restrictedModels <- options[["restrictedModels"]]
@@ -848,7 +848,7 @@ Ancova <- function(jaspResults, dataset = NULL, options) {
 }
 
 .anovaOrdinalRestrictionsCalcBaseModel <- function(ordinalRestrictionsContainer, dataset, options) {
-  if (!is.null(ordinalRestrictionsContainer[["baseModel"]])) return()
+  if (!is.null(ordinalRestrictionsContainer[["baseModel"]])) return(ordinalRestrictionsContainer[["baseModel"]]$object)
 
   baseModel <- createJaspState()
   baseModel$dependOn(c("includeIntercept"))
@@ -915,7 +915,8 @@ Ancova <- function(jaspResults, dataset = NULL, options) {
 
 .anovaOrdinalRestrictionsComputeModel <- function(model, baseModel, container, dataset, options) {
   modelName <- model[["modelName"]]
-  if (!is.null(container[[modelName]]) || model[["restrictionSyntax"]] == "") return()
+  if (model[["restrictionSyntax"]] == "") return()
+  if (!is.null(container[[modelName]])) return(container[[modelName]]$object)
 
   translatedSyntax <- .anovaOrdinalRestrictionsTranslateSyntax(model[["restrictionSyntax"]], dataset)
 
@@ -956,7 +957,8 @@ Ancova <- function(jaspResults, dataset = NULL, options) {
 }
 
 .anovaOrdinalRestrictionsCompareModels <- function(modelList, ordinalRestrictionsContainer, options) {
-  if (!is.null(ordinalRestrictionsContainer[["modelComparison"]]) || ordinalRestrictionsContainer$getError()) return()
+  if (ordinalRestrictionsContainer$getError()) return()
+  if (!is.null(ordinalRestrictionsContainer[["modelComparison"]])) return(ordinalRestrictionsContainer[["modelComparison"]]$object)
 
   modelComparison <- createJaspState()
   modelComparison$dependOn(c("restrictedModelComparison"))

--- a/R/ancova.R
+++ b/R/ancova.R
@@ -801,13 +801,17 @@ Ancova <- function(jaspResults, dataset = NULL, options) {
 
 .anovaOrdinalRestrictions <- function(anovaContainer, dataset, options, ready) {
   if (!ready) return()
+  if (is.null(anovaContainer[["ordinalRestrictions"]])) {
+    ordinalRestrictionsContainer <- createJaspContainer(title = gettext("Order Restrictions"), dependencies = "restrictedModels")
+    anovaContainer[["ordinalRestrictions"]] <- ordinalRestrictionsContainer
+  } else {
+    orginalRestrictionsContainer <- anovaContainer[["ordinalRestrictions"]]
+  }
 
   restrictedModels <- options[["restrictedModels"]]
   restrictedModels <- restrictedModels[vapply(restrictedModels, function(mod) mod[["restrictionSyntax"]] != "", logical(1))]
   if (length(restrictedModels) == 0L) return()
 
-  ordinalRestrictionsContainer <- createJaspContainer(title = gettext("Order Restrictions"))
-  anovaContainer[["ordinalRestrictions"]] <- ordinalRestrictionsContainer
 
   baseModel <- .anovaOrdinalRestrictionsCalcBaseModel(ordinalRestrictionsContainer, dataset, options)
 

--- a/R/ancova.R
+++ b/R/ancova.R
@@ -1053,8 +1053,12 @@ Ancova <- function(jaspResults, dataset = NULL, options) {
   else
     weights <- compareDf[["gorica.weights"]]
 
-  ratio <- weights/weights[nms == reference]
-  compareDf[["ratio"]] <- ratio
+  if (reference %in% nms) {
+    ratio <- weights/weights[nms == reference]
+    compareDf[["ratio"]] <- ratio
+  } else {
+    comparisonTable$addFootnote(colNames = "ratio", message = gettextf("Model '%s' cannot be a reference model as it is empty!", reference))
+  }
 
   if (length(nms) == 1)
     comparisonTable$addRows(as.list(compareDf))

--- a/R/anovarepeatedmeasures.R
+++ b/R/anovarepeatedmeasures.R
@@ -991,7 +991,7 @@ AnovaRepeatedMeasures <- function(jaspResults, dataset = NULL, options) {
 
   restrictionSyntax <- vapply(restrictedModels, "[[", "restrictionSyntax", FUN.VALUE = character(1))
   translatedSyntax  <- vapply(restrictionSyntax, .rmAnovaOrdinalRestrictionsTranslateSyntax, dataset = dataset, options = options, FUN.VALUE = character(1))
-
+  names(translatedSyntax) <- vapply(restrictedModels, "[[", "modelName", FUN.VALUE = character(1))
   if (any(sapply(translatedSyntax, isTryError))) {
     modelNames       <- vapply(restrictedModels, "[[", "modelName", FUN.VALUE = character(1))
     modelHasErrors   <- modelNames[sapply(translatedSyntax, isTryError)]

--- a/R/anovarepeatedmeasures.R
+++ b/R/anovarepeatedmeasures.R
@@ -874,8 +874,10 @@ AnovaRepeatedMeasures <- function(jaspResults, dataset = NULL, options) {
 
   if (length(options[["restrictedModelMarginalMeansTerm"]]) > 0L) {
     modelSummaryList <- .rmAnovaOrdinalRestrictionsCalcModelSummaries(compareGoric, modelNames, baseModel, wideData, ordinalRestrictionsContainer, options)
-    .ordinalRestrictionsCreateModelSummaryTables(modelSummaryList, ordinalRestrictionsContainer, type = "gorica", options)
+  } else {
+    modelSummaryList <- NULL
   }
+  .ordinalRestrictionsCreateModelSummaryTables(modelSummaryList, ordinalRestrictionsContainer, type = "gorica", options)
 
   if (length(options[["plotRestrictedModels"]]) > 0L && length(options[["restrictedModelMarginalMeansTerm"]]) > 0L)
     .ordinalRestrictionsCreateMarginalMeansPlot(modelSummaryList, modelNames, ordinalRestrictionsContainer, options)

--- a/R/anovarepeatedmeasures.R
+++ b/R/anovarepeatedmeasures.R
@@ -864,6 +864,7 @@ AnovaRepeatedMeasures <- function(jaspResults, dataset = NULL, options) {
 
   modelNames <- vapply(restrictedModels, "[[", "modelName", FUN.VALUE = character(1))
 
+  .anovaOrdinalRestrictionsCustomCheckSyntax(restrictedModels, ordinalRestrictionsContainer)
   compareGoric <- .rmAnovaOrdinalRestrictionsCompareModels(baseModel, restrictedModels, ordinalRestrictionsContainer, longData, options)
   .rmAnovaOrdinalRestrictionsGetSyntaxErrors(compareGoric, ordinalRestrictionsContainer)
   .ordinalRestrictionsCreateComparisonTable(compareGoric, modelNames, ordinalRestrictionsContainer, type = "gorica", options)

--- a/inst/qml/common/OrderRestrictions.qml
+++ b/inst/qml/common/OrderRestrictions.qml
@@ -30,12 +30,12 @@ Section
 	
 	Text
 	{
-		text: qsTr("Place each restriction on a new line. For example:\n\nfactorLow == factorMed == factorHigh\nfactorLow < factorMed < factorHigh\n\nwhere factor is the factor name and Low/Med/High are the factor level names.")
+		text: qsTr("Place each restriction on a new line. For example:\n\nfactorLow == factorMed\nfactorMed < factorHigh\n\nwhere factor is the factor name and Low/Med/High are the factor level names.")
 	}
 
 	Text
 	{
-		text: qsTr("In case that the intercept is included,\nthe reference level of the first factor in the model is replaced by the .Intercept. keyword.\nThe corresponding syntax for the above equality restriction would be:\n\n .Intercept. == factorMed == factorHigh")
+		text: qsTr("In case that the intercept is included,\nthe reference level of the first factor in the model is replaced by the .Intercept. keyword.\nThe corresponding syntax for the above equality restriction would be:\n\n.Intercept. == .Intercept. + factorMed\nfactorMed < factorHigh")
 		visible: type !== "RM-Anova"
 	}
 

--- a/inst/qml/common/OrderRestrictions.qml
+++ b/inst/qml/common/OrderRestrictions.qml
@@ -30,7 +30,19 @@ Section
 	
 	Text
 	{
-		text: qsTr("Place each restriction on a new line. For example:\n\nfactorLow = factorMed = factorHigh\nfactorLow < factorMed < factorHigh\n\nwhere factor is the factor name and Low/Med/High are the factor level names.")
+		text: qsTr("Place each restriction on a new line. For example:\n\nfactorLow == factorMed == factorHigh\nfactorLow < factorMed < factorHigh\n\nwhere factor is the factor name and Low/Med/High are the factor level names.")
+	}
+
+	Text
+	{
+		text: qsTr("In case that the intercept is included,\nthe reference level of the first factor in the model is replaced by the .Intercept. keyword.\nThe corresponding syntax for the above equality restriction would be:\n\n .Intercept. == factorMed == factorHigh")
+		visible: type !== "RM-Anova"
+	}
+
+	HelpButton
+	{
+		toolTip: qsTr("Click to learn more about the syntax for order restrictions.")
+		helpPage: "goric/restriktorSyntax"
 	}
 	
 	Form
@@ -96,12 +108,6 @@ Section
 								checked: true
 							}
 						}
-					}
-					
-					HelpButton
-					{
-						toolTip: qsTr("Click to learn more about the syntax for order restrictions.")
-						helpPage: "goric/restriktorSyntax"
 					}
 				}
 			}

--- a/inst/qml/common/OrderRestrictions.qml
+++ b/inst/qml/common/OrderRestrictions.qml
@@ -206,6 +206,7 @@ Section
 				{
 					name: "restrictedConfidenceIntervalBootstrapSamples"
 					defaultValue: 1000
+					min: 100
 					afterLabel: qsTr("bootstraps")
 				}
 			}


### PR DESCRIPTION
fixes https://github.com/jasp-stats/jasp-test-release/issues/1590
fixes https://github.com/jasp-stats/jasp-test-release/issues/1589
fixes https://github.com/jasp-stats/jasp-test-release/issues/1587
fixes https://github.com/jasp-stats/jasp-test-release/issues/1586
fixes https://github.com/jasp-stats/jasp-test-release/issues/1578
fixes https://github.com/jasp-stats/jasp-test-release/issues/1579
fixes https://github.com/jasp-stats/jasp-test-release/issues/1580
fixes https://github.com/jasp-stats/jasp-test-release/issues/1581
fixes https://github.com/jasp-stats/jasp-test-release/issues/1583
fixes https://github.com/jasp-stats/jasp-test-release/issues/1584

I attempted to also fix the following issues, but those fixes may need some discussion:

- [x] https://github.com/jasp-stats/jasp-test-release/issues/1584
- [ ] https://github.com/jasp-stats/jasp-test-release/issues/1585

These issues are currently tackled by disallowing multiple constraints in one line. The problem is that there is a bug in the package that leads to incorrect results for constraints like `factor1 > factor2 > factor3`. 

Additional issue is that specifying an order restriction like 

```
DrinkBeer > DrinkWine
DrinkWine > DrinkWater
DrinkBeer > DrinkWater
```

would correctly lead to the same estimates and likelihood as 

```
DrinkBeer > DrinkWine
DrinkWine > DrinkWater
```

but the two models would have different penalty for some reason (even though intuitively they are the same, as one of the restrictions is redundant).

The maintainers of the package have been informed about this, but at the moment, I cannot do anything to fix it.

- [x] https://github.com/jasp-stats/jasp-test-release/issues/1582
- [x] https://github.com/jasp-stats/jasp-test-release/issues/1587 (screenshot 2)

These errors are caused in the qml, I made an issue for it here: https://github.com/jasp-stats/INTERNAL-jasp/issues/1607