### PR TITLE
append dependendent variable to raincloud plot title

### DIFF
--- a/R/commonAnovaBayesian.R
+++ b/R/commonAnovaBayesian.R
@@ -1764,7 +1764,7 @@ BANOVAcomputMatchedInclusion <- function(effectNames, effects.matrix, interactio
   if (options$rainCloudPlotsSeparatePlots != "") {
     for (thisLevel in levels(dataset[[options[["rainCloudPlotsSeparatePlots"]]]])) {
       subData      <- dataset[dataset[[options[["rainCloudPlotsSeparatePlots"]]]] == thisLevel, ]
-      thisPlotName <- paste0(options[["rainCloudPlotsSeparatePlots"]], ": ", thisLevel)
+      thisPlotName <- paste0(dependentV, ": ", options[["rainCloudPlotsSeparatePlots"]], ": ", thisLevel)
       subPlot      <- createJaspPlot(title = thisPlotName, width = 480, height = 320)
       rainCloudPlotsContainer[[thisLevel]] <- subPlot
       p <- try(jaspTTests::.descriptivesPlotsRainCloudFill(subData, dependentV, groupVar, yLabel, groupVar, addLines, horiz, NULL))
@@ -1774,7 +1774,7 @@ BANOVAcomputMatchedInclusion <- function(effectNames, effects.matrix, interactio
         subPlot$plotObject <- p
     }
   } else {
-    singlePlot <- createJaspPlot(title = "", width = 480, height = 320)
+    singlePlot <- createJaspPlot(title = dependentV, width = 480, height = 320)
     rainCloudPlotsContainer[["rainCloudPlotSingle"]] <- singlePlot
     p <- try(jaspTTests::.descriptivesPlotsRainCloudFill(dataset, dependentV, groupVar, yLabel, groupVar, addLines, horiz, NULL))
     if(isTryError(p))


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/1565


![image](https://user-images.githubusercontent.com/58136327/152336903-14a3eff3-5a70-405e-b2d8-df3f5859baa9.png)


The original issue as reported was that it was hard to save a raincloud plot in the ANOVA module because by default there was no title on the innermost container of the plot, so attention was not directed to the menu that facilitates the 'save' (see screenshots above and below). If the 'separate plots' option is used then there was a title to draw attention to the menu, but this did not include the name of the dependent variable.

![image](https://user-images.githubusercontent.com/58136327/152336989-afa93b76-6c86-4b1b-8237-c5d34986e338.png)

Alexander and I agreed that the idea functionality would be that the dependent variable would be used as a title in the case of a single plot, and would also be appended to the beginning of the title in the case of separated plots, see the screenshots below.

![image](https://user-images.githubusercontent.com/58136327/152338569-02a1325f-32e9-4bbd-b0df-41da7f28d764.png)



![image](https://user-images.githubusercontent.com/58136327/152338632-966c109d-f70f-48e9-8f6f-d43749b7ea46.png)
