### PR TITLE
Raincloud lines now also adapted to Bayesian ANOVA

### DIFF
--- a/R/commonAnovaBayesian.R
+++ b/R/commonAnovaBayesian.R
@@ -1819,7 +1819,7 @@ BANOVAcomputMatchedInclusion <- function(effectNames, effects.matrix, interactio
 
   groupVar <- options[["rainCloudPlotsHorizontalAxis"]]
   if (analysisType == "RM-ANOVA") {
-    addLines   <- groupVar %in% unlist(options[["withinModelTerms"]])
+    addLines   <- !(groupVar %in% unlist(options[["betweenSubjectFactors"]]))
     dependentV <- .BANOVAdependentName
     yLabel     <- options[["rainCloudPlotsLabelYAxis"]]
   } else {


### PR DESCRIPTION
I missed the different option terminology in the BANOVA.. now it should work for both Bayesian and freq RM ANOVA.
Fix https://github.com/jasp-stats/INTERNAL-jasp/issues/1824 