### PR TITLE
Remove side effects of AN(C)OVA and RM ANOVA

### DIFF
--- a/R/ancova.R
+++ b/R/ancova.R
@@ -22,6 +22,8 @@ gettextf <- function(fmt, ..., domain = NULL)  {
 }
 
 Ancova <- function(jaspResults, dataset = NULL, options) {
+  initialGlobalOptions <- options()
+  on.exit(options(initialGlobalOptions), add = TRUE)
 
   numericVariables <- c(unlist(options$dependent),unlist(options$covariates),unlist(options$wlsWeight))
   numericVariables <- numericVariables[numericVariables != ""]

--- a/R/anovarepeatedmeasures.R
+++ b/R/anovarepeatedmeasures.R
@@ -15,6 +15,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 AnovaRepeatedMeasures <- function(jaspResults, dataset = NULL, options) {
+  initialGlobalOptions <- options()
+  on.exit(options(initialGlobalOptions), add = TRUE)
 
   numericVariables <- c(unlist(options$repeatedMeasuresCells),unlist(options$covariates))
   numericVariables <- numericVariables[numericVariables != ""]


### PR DESCRIPTION
fixes https://github.com/jasp-stats/jasp-issues/issues/1677

As discussed, this fix is really only needed for this release, as soon we will have one engine per module, which would fix that too. Also, we may want to reset the options more generally (either in jaspBase or jaspTools) to ensure that JASP analyses do not have side effects in R either. 