### PR TITLE
Implement maximum for sphericity corrections (try 2)

### DIFF
--- a/R/anovarepeatedmeasures.R
+++ b/R/anovarepeatedmeasures.R
@@ -437,6 +437,7 @@ AnovaRepeatedMeasures <- function(jaspResults, dataset = NULL, options) {
 
   withinIndices <- .mapAnovaTermsToTerms(rownames(withinAnovaTable), rownames(corrections))
 
+  # set 1 as an upper-bound of the correction factors, see https://github.com/jasp-stats/jasp-issues/issues/1709
   ggCorrections <- pmin(corrections[withinIndices, "GG eps"], 1)
   hfCorrections <- pmin(corrections[withinIndices, "HF eps"], 1)
   


### PR DESCRIPTION
The correcting factor should not exceed 1- this is now implemented.
Fix https://github.com/jasp-stats/jasp-issues/issues/1709

@JTPetter 
"Yes, I think we could use Broca dataset to verify the results for the corrections. I will wait for this to be merged and then verify the results."