### PR TITLE
[Syntax] Rename options for classical ANOVA, ANCOVA, and RMANOVA

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: jaspAnova
 Type: Package
 Title: ANOVA Module for JASP
-Version: 0.16.3
+Version: 0.16.4
 Date: 2020-04-20
 Author: JASP Team
 Website: jasp-stats.org

--- a/R/ancova.R
+++ b/R/ancova.R
@@ -36,9 +36,9 @@ Ancova <- function(jaspResults, dataset = NULL, options) {
 
   # Set corrections to FALSE when performing ANCOVA
   if (is.null(options$homogeneityBrown)) {
-    options$homogeneityNone <- TRUE
-    options$homogeneityBrown <- FALSE
-    options$homogeneityWelch <- FALSE
+    options$homogeneityCorrectionNone <- TRUE
+    options$homogeneityCorrectionBrown <- FALSE
+    options$homogeneityCorrectionWelch <- FALSE
   }
 
   if (is.null(dataset)) {

--- a/R/anovarepeatedmeasures.R
+++ b/R/anovarepeatedmeasures.R
@@ -1052,7 +1052,9 @@ AnovaRepeatedMeasures <- function(jaspResults, dataset = NULL, options) {
 
   postHocTable$addColumnInfo(name="t.ratio", title=gettext("t"), type="number")
 
-  if (options$postHocTypeStandardEffectSize || options$postHocEffectSize) {
+  # postHocTypeStandardEffectSize is from AN(C)OVA
+  # postHocEffectSize is from RMANOVA
+  if (isTRUE(options$postHocTypeStandardEffectSize) || isTRUE(options$postHocEffectSize)) {
     postHocTable$addColumnInfo(name="cohenD", title=gettext("Cohen's d"), type="number")
 
     if (isFALSE(options$postHocPooledError))

--- a/R/anovarepeatedmeasures.R
+++ b/R/anovarepeatedmeasures.R
@@ -288,7 +288,7 @@ AnovaRepeatedMeasures <- function(jaspResults, dataset = NULL, options) {
       result <- stats::aov(model.formula, data=dataset)
       summaryResultOne <- summary(result, expand.split = FALSE)
 
-      result <- afex::aov_car(model.formula, data=dataset, type= 3, factorize = FALSE, 
+      result <- afex::aov_car(model.formula, data=dataset, type= 3, factorize = FALSE,
                               include_aov = isFALSE(options[["useMultivariateModelFollowup"]]))
       summaryResult <- summary(result)
 
@@ -311,7 +311,7 @@ AnovaRepeatedMeasures <- function(jaspResults, dataset = NULL, options) {
     } else if (options$sumOfSquares == "type2") {
 
     tryResult <- try({
-      result <- afex::aov_car(model.formula, data=dataset, type= 2, factorize = FALSE, 
+      result <- afex::aov_car(model.formula, data=dataset, type= 2, factorize = FALSE,
                               include_aov = isFALSE(options[["useMultivariateModelFollowup"]]))
       summaryResult <- summary(result)
       model <- as.data.frame(unclass(summaryResult$univariate.tests))
@@ -320,7 +320,7 @@ AnovaRepeatedMeasures <- function(jaspResults, dataset = NULL, options) {
   } else {
 
     tryResult <- try({
-      result <- afex::aov_car(model.formula, data=dataset, type= 3, factorize = FALSE, 
+      result <- afex::aov_car(model.formula, data=dataset, type= 3, factorize = FALSE,
                               include_aov = isFALSE(options[["useMultivariateModelFollowup"]]))
       summaryResult <- summary(result)
       model <- as.data.frame(unclass(summaryResult$univariate.tests))
@@ -1032,12 +1032,12 @@ AnovaRepeatedMeasures <- function(jaspResults, dataset = NULL, options) {
 
   postHocTable$addColumnInfo(name="estimate", title=gettext("Mean Difference"), type="number")
 
-  if (options$confidenceIntervalsPostHoc || makeBootstrapTable) {
+  if (options$postHocCi || makeBootstrapTable) {
 
     if (makeBootstrapTable) {
-      thisOverTitle <- gettextf("%1$s%% bca%2$s CI", options$confidenceIntervalIntervalPostHoc * 100, "\u2020")
+      thisOverTitle <- gettextf("%1$s%% bca%2$s CI", options$postHocCiLevel * 100, "\u2020")
     } else {
-      thisOverTitle <- gettextf("%s%% CI for Mean Difference", options$confidenceIntervalIntervalPostHoc * 100)
+      thisOverTitle <- gettextf("%s%% CI for Mean Difference", options$postHocCiLevel * 100)
     }
 
     postHocTable$addColumnInfo(name="lower.CL", type = "number", title = gettext("Lower"), overtitle = thisOverTitle)
@@ -1052,32 +1052,32 @@ AnovaRepeatedMeasures <- function(jaspResults, dataset = NULL, options) {
 
   postHocTable$addColumnInfo(name="t.ratio", title=gettext("t"), type="number")
 
-  if (options$postHocTestEffectSize) {
+  if (options$postHocTypeStandardEffectSize) {
     postHocTable$addColumnInfo(name="cohenD", title=gettext("Cohen's d"), type="number")
 
-    if (isFALSE(options$postHocTestPooledError))
+    if (isFALSE(options$postHocPooledError))
       postHocTable$addFootnote(gettext("Computation of Cohen's d based on pooled error."))
 
-    if (options$confidenceIntervalsPostHoc) {
-      thisOverTitleCohenD <- gettextf("%s%% CI for Cohen's d", options$confidenceIntervalIntervalPostHoc * 100)
+    if (options$postHocCi) {
+      thisOverTitleCohenD <- gettextf("%s%% CI for Cohen's d", options$postHocCiLevel * 100)
       postHocTable$addColumnInfo(name="cohenD_LowerCI", type = "number", title = gettext("Lower"), overtitle = thisOverTitleCohenD)
       postHocTable$addColumnInfo(name="cohenD_UpperCI", type = "number", title = gettext("Upper"), overtitle = thisOverTitleCohenD)
     }
   }
 
-  if (options$postHocTestsTukey)
+  if (options$postHocCorrectionTukey)
     postHocTable$addColumnInfo(name="tukey",    title=gettext("p<sub>tukey</sub>"), type="pvalue")
 
-  if (options$postHocTestsScheffe)
+  if (options$postHocCorrectionScheffe)
     postHocTable$addColumnInfo(name="scheffe", title=gettext("p<sub>scheffe</sub>"), type="pvalue")
 
-  if (options$postHocTestsBonferroni)
+  if (options$postHocCorrectionBonferroni)
     postHocTable$addColumnInfo(name="bonferroni", title=gettext("p<sub>bonf</sub>"), type="pvalue")
 
-  if (options$postHocTestsHolm)
+  if (options$postHocCorrectionHolm)
     postHocTable$addColumnInfo(name="holm", title=gettext("p<sub>holm</sub>"), type="pvalue")
 
-  if (options$postHocTestsSidak)
+  if (options$postHocCorrectionSidak)
     postHocTable$addColumnInfo(name="sidak", title=gettext("p<sub>sidak</sub>"), type="pvalue")
 
 
@@ -1231,7 +1231,7 @@ AnovaRepeatedMeasures <- function(jaspResults, dataset = NULL, options) {
     return ()
 
   marginalMeansContainer <- createJaspContainer(title = gettext("Marginal Means"))
-  marginalMeansContainer$dependOn(c("marginalMeansTerms",  "marginalMeansCompareMainEffects", "marginalMeansCIAdjustment",
+  marginalMeansContainer$dependOn(c("marginalMeansTerms",  "marginalMeanComparedToZero", "marginalMeansCIAdjustment",
                                     "marginalMeansBootstrapping", "marginalMeansBootstrappingReplicates"))
 
   rmAnovaContainer[["marginalMeansContainer"]] <- marginalMeansContainer
@@ -1360,14 +1360,14 @@ AnovaRepeatedMeasures <- function(jaspResults, dataset = NULL, options) {
 
   marginalMeansTable$addColumnInfo(name="SE", title=gettext("SE"), type="number")
 
-  if (options$marginalMeansCompareMainEffects) {
+  if (options$marginalMeanComparedToZero) {
     marginalMeansTable$addColumnInfo(name="t.ratio", title=gettext("t"),  type="number")
     marginalMeansTable$addColumnInfo(name="df",      title=gettext("df"), type=dfType)
     marginalMeansTable$addColumnInfo(name="p.value", title=gettext("p"),  type="pvalue")
 
-    if (options$marginalMeansCIAdjustment == "bonferroni") {
+    if (options$marginalMeanCiCorrection == "bonferroni") {
       marginalMeansTable$addFootnote(message = gettext("Bonferroni CI adjustment"))
-    } else if (options$marginalMeansCIAdjustment == "sidak") {
+    } else if (options$marginalMeanCiCorrection == "sidak") {
       marginalMeansTable$addFootnote(message = gettext("Sidak CI adjustment"))
     }
   }

--- a/R/anovarepeatedmeasures.R
+++ b/R/anovarepeatedmeasures.R
@@ -440,7 +440,7 @@ AnovaRepeatedMeasures <- function(jaspResults, dataset = NULL, options) {
   # set 1 as an upper-bound of the correction factors, see https://github.com/jasp-stats/jasp-issues/issues/1709
   ggCorrections <- pmin(corrections[withinIndices, "GG eps"], 1)
   hfCorrections <- pmin(corrections[withinIndices, "HF eps"], 1)
-  
+
   ggTable[["num Df"]]          <- withinAnovaTable[["num Df"]] * ggCorrections
   ggTable[["Mean Sq"]]         <- withinAnovaTable[["Sum Sq"]] / ggTable[["num Df"]]
   ggTable[["den Df"]]          <- withinAnovaTable[["den Df"]] * ggCorrections
@@ -522,7 +522,7 @@ AnovaRepeatedMeasures <- function(jaspResults, dataset = NULL, options) {
 
   betweenTable <- createJaspTable(title = gettext("Between Subjects Effects"), position = 2)
   betweenTable$dependOn(c("effectSizeEstimates", "effectSizeEtaSquared", "effectSizePartialEtaSquared",
-                             "effectSizeGenEtaSquared", "effectSizeOmegaSquared", "vovkSellke"))
+                             "effectSizeGeneralEtaSquared", "effectSizeOmegaSquared", "vovkSellke"))
 
   betweenTable$addColumnInfo(title = gettext("Cases"),          name = "case",    type = "string" )
   betweenTable$addColumnInfo(title = gettext("Sum of Squares"), name = "Sum Sq",  type = "number")
@@ -544,7 +544,7 @@ AnovaRepeatedMeasures <- function(jaspResults, dataset = NULL, options) {
     if (options$effectSizePartialEtaSquared)
       betweenTable$addColumnInfo(title = "\u03B7\u00B2\u209A", name = "etaPart", type = "number")
 
-    if (options$effectSizeGenEtaSquared)
+    if (options$effectSizeGeneralEtaSquared)
       betweenTable$addColumnInfo(title = gettextf("%s<sub>G</sub>", "\u03B7\u00B2"), name = "genEta", type = "number")
 
     if (options$effectSizeOmegaSquared)
@@ -586,7 +586,7 @@ AnovaRepeatedMeasures <- function(jaspResults, dataset = NULL, options) {
   anovaTable$showSpecifiedColumnsOnly <- TRUE
   anovaTable$dependOn(c("sphericityCorrectionGreenhouseGeisser", "sphericityCorrectionHuynhFeldt",
                         "sphericityCorrectionNone", "vovkSellke", "effectSizeEstimates", "effectSizeEtaSquared",
-                        "effectSizePartialEtaSquared", "effectSizeGenEtaSquared", "effectSizeOmegaSquared"))
+                        "effectSizePartialEtaSquared", "effectSizeGeneralEtaSquared", "effectSizeOmegaSquared"))
 
   corrections <- c("None", "Greenhouse-Geisser", "Huynh-Feldt")[c(options$sphericityCorrectionNone,
                                                                  options$sphericityCorrectionGreenhouseGeisser,
@@ -622,7 +622,7 @@ AnovaRepeatedMeasures <- function(jaspResults, dataset = NULL, options) {
       anovaTable$addColumnInfo(title = "\u03B7\u00B2\u209A", name = "etaPart", type = "number")
     }
 
-    if(options$effectSizeGenEtaSquared) {
+    if(options$effectSizeGeneralEtaSquared) {
       anovaTable$addColumnInfo(name="genEta", type="number", title=gettextf("%s<sub>G</sub>", "\u03B7\u00B2"))
     }
 

--- a/R/anovarepeatedmeasures.R
+++ b/R/anovarepeatedmeasures.R
@@ -77,7 +77,7 @@ AnovaRepeatedMeasures <- function(jaspResults, dataset = NULL, options) {
     anovaContainer <- createJaspContainer()
     # we set the dependencies on the container, this means that all items inside the container automatically have these dependencies
     anovaContainer$dependOn(c("withinModelTerms", "betweenModelTerms", "repeatedMeasuresCells", "betweenSubjectFactors",
-                              "repeatedMeasuresFactors", "covariates", "sumOfSquares", "useMultivariateModelFollowup"))
+                              "repeatedMeasuresFactors", "covariates", "sumOfSquares", "multivariateModelFollowup"))
     jaspResults[["rmAnovaContainer"]] <- anovaContainer
   }
 
@@ -273,7 +273,7 @@ AnovaRepeatedMeasures <- function(jaspResults, dataset = NULL, options) {
 
   # set these options once for all afex::aov_car calls,
   # this ensures for instance that afex::aov_car always returns objects of class afex_aov.
-  if (options$useMultivariateModelFollowup)   followupModelType <- "multivariate" else followupModelType <- "univariate"
+  if (options$multivariateModelFollowup)   followupModelType <- "multivariate" else followupModelType <- "univariate"
   afex::afex_options(
     check_contrasts = TRUE, correction_aov = "GG",
     emmeans_model = followupModelType, es_aov = "ges", factorize = TRUE,
@@ -289,7 +289,7 @@ AnovaRepeatedMeasures <- function(jaspResults, dataset = NULL, options) {
       summaryResultOne <- summary(result, expand.split = FALSE)
 
       result <- afex::aov_car(model.formula, data=dataset, type= 3, factorize = FALSE,
-                              include_aov = isFALSE(options[["useMultivariateModelFollowup"]]))
+                              include_aov = isFALSE(options[["multivariateModelFollowup"]]))
       summaryResult <- summary(result)
 
       # Reformat the results to make it consistent with types 2 and 3
@@ -312,7 +312,7 @@ AnovaRepeatedMeasures <- function(jaspResults, dataset = NULL, options) {
 
     tryResult <- try({
       result <- afex::aov_car(model.formula, data=dataset, type= 2, factorize = FALSE,
-                              include_aov = isFALSE(options[["useMultivariateModelFollowup"]]))
+                              include_aov = isFALSE(options[["multivariateModelFollowup"]]))
       summaryResult <- summary(result)
       model <- as.data.frame(unclass(summaryResult$univariate.tests))
     })
@@ -321,7 +321,7 @@ AnovaRepeatedMeasures <- function(jaspResults, dataset = NULL, options) {
 
     tryResult <- try({
       result <- afex::aov_car(model.formula, data=dataset, type= 3, factorize = FALSE,
-                              include_aov = isFALSE(options[["useMultivariateModelFollowup"]]))
+                              include_aov = isFALSE(options[["multivariateModelFollowup"]]))
       summaryResult <- summary(result)
       model <- as.data.frame(unclass(summaryResult$univariate.tests))
     })
@@ -371,7 +371,7 @@ AnovaRepeatedMeasures <- function(jaspResults, dataset = NULL, options) {
 
   sortedModel[["case"]] <- unlist(modelDef$terms.normal)[mappedRownamesCases]
   sortedModel[["Mean Sq"]] <- sortedModel[["Sum Sq"]] / sortedModel[["num Df"]]
-  sortedModel[["VovkSellkeMPR"]] <- VovkSellkeMPR(sortedModel[["Pr(>F)"]])
+  sortedModel[["vovkSellke"]] <- VovkSellkeMPR(sortedModel[["Pr(>F)"]])
 
   rownames(residualResults) <- cases
   residualResults[["Mean Sq"]] <- residualResults[["Sum Sq"]] / residualResults[["num Df"]]
@@ -486,7 +486,7 @@ AnovaRepeatedMeasures <- function(jaspResults, dataset = NULL, options) {
   wResidualResultsList[["None"]]["BetweenResidualResults", "Mean Sq"] <- interceptRow[["Error SS"]] / interceptRow[["den Df"]]
 
   for (tableIndex in seq_along(withinAnovaTableCollection)) {
-    withinAnovaTableCollection[[tableIndex]][["VovkSellkeMPR"]] <- VovkSellkeMPR(withinAnovaTableCollection[[tableIndex]][["Pr(>F)"]])
+    withinAnovaTableCollection[[tableIndex]][["vovkSellke"]] <- VovkSellkeMPR(withinAnovaTableCollection[[tableIndex]][["Pr(>F)"]])
   }
 
   return(list(anovaResult = sortedModel,
@@ -522,7 +522,7 @@ AnovaRepeatedMeasures <- function(jaspResults, dataset = NULL, options) {
 
   betweenTable <- createJaspTable(title = gettext("Between Subjects Effects"), position = 2)
   betweenTable$dependOn(c("effectSizeEstimates", "effectSizeEtaSquared", "effectSizePartialEtaSquared",
-                             "effectSizeGenEtaSquared", "effectSizeOmegaSquared", "VovkSellkeMPR"))
+                             "effectSizeGenEtaSquared", "effectSizeOmegaSquared", "vovkSellke"))
 
   betweenTable$addColumnInfo(title = gettext("Cases"),          name = "case",    type = "string" )
   betweenTable$addColumnInfo(title = gettext("Sum of Squares"), name = "Sum Sq",  type = "number")
@@ -531,8 +531,8 @@ AnovaRepeatedMeasures <- function(jaspResults, dataset = NULL, options) {
   betweenTable$addColumnInfo(title = gettext("F"),              name = "F value", type = "number")
   betweenTable$addColumnInfo(title = gettext("p"),              name = "Pr(>F)",  type = "pvalue")
 
-  if (options$VovkSellkeMPR && length(options$betweenSubjectFactors) > 0) {
-    betweenTable$addColumnInfo(title = gettextf("VS-MPR%s", "\u002A"), name = "VovkSellkeMPR", type = "number")
+  if (options$vovkSellke && length(options$betweenSubjectFactors) > 0) {
+    betweenTable$addColumnInfo(title = gettextf("VS-MPR%s", "\u002A"), name = "vovkSellke", type = "number")
     betweenTable$addFootnote(message = .messages("footnote", "VovkSellkeMPR"), symbol = "\u002A")
   }
 
@@ -584,13 +584,13 @@ AnovaRepeatedMeasures <- function(jaspResults, dataset = NULL, options) {
   anovaTable <- createJaspTable(title = gettext("Within Subjects Effects"), position = 1)
   rmAnovaContainer[["withinAnovaTable"]] <- anovaTable
   anovaTable$showSpecifiedColumnsOnly <- TRUE
-  anovaTable$dependOn(c("sphericityGreenhouseGeisser", "sphericityHuynhFeldt",
-                        "sphericityNone", "VovkSellkeMPR", "effectSizeEstimates", "effectSizeEtaSquared",
+  anovaTable$dependOn(c("sphericityCorrectionGreenhouseGeisser", "sphericityCorrectionHuynhFeldt",
+                        "sphericityCorrectionNone", "vovkSellke", "effectSizeEstimates", "effectSizeEtaSquared",
                         "effectSizePartialEtaSquared", "effectSizeGenEtaSquared", "effectSizeOmegaSquared"))
 
-  corrections <- c("None", "Greenhouse-Geisser", "Huynh-Feldt")[c(options$sphericityNone,
-                                                                 options$sphericityGreenhouseGeisser,
-                                                                 options$sphericityHuynhFeldt)]
+  corrections <- c("None", "Greenhouse-Geisser", "Huynh-Feldt")[c(options$sphericityCorrectionNone,
+                                                                 options$sphericityCorrectionGreenhouseGeisser,
+                                                                 options$sphericityCorrectionHuynhFeldt)]
   if (length(corrections) == 0) corrections <- "None"
 
   anovaTable$addColumnInfo(title = gettext("Cases"), name = "case", type = "string", combine = TRUE)
@@ -607,8 +607,8 @@ AnovaRepeatedMeasures <- function(jaspResults, dataset = NULL, options) {
   anovaTable$addColumnInfo(title = gettext("F"),              name = "F value", type = "number")
   anovaTable$addColumnInfo(title = gettext("p"),              name = "p",       type = "pvalue")
 
-  if (options$VovkSellkeMPR) {
-    anovaTable$addColumnInfo(title = gettextf("VS-MPR%s", "\u002A"), name = "VovkSellkeMPR", type = "number")
+  if (options$vovkSellke) {
+    anovaTable$addColumnInfo(title = gettextf("VS-MPR%s", "\u002A"), name = "vovkSellke", type = "number")
     anovaTable$addFootnote(message = .messages("footnote", "VovkSellkeMPR"), symbol = "\u002A")
   }
 
@@ -722,8 +722,8 @@ AnovaRepeatedMeasures <- function(jaspResults, dataset = NULL, options) {
   rmAnovaLevenesTable$addColumnInfo(name="df2", type="integer")
   rmAnovaLevenesTable$addColumnInfo(name="p", type="pvalue")
 
-  if (options$VovkSellkeMPR) {
-    rmAnovaLevenesTable$addColumnInfo(title = "VS-MPR\u002A", name = "VovkSellkeMPR", type = "number")
+  if (options$vovkSellke) {
+    rmAnovaLevenesTable$addColumnInfo(title = "VS-MPR\u002A", name = "vovkSellke", type = "number")
     rmAnovaLevenesTable$addFootnote(message = .messages("footnote", "VovkSellkeMPR"), symbol = "\u002A")
   }
   rmAnovaLevenesTable$showSpecifiedColumnsOnly <- TRUE
@@ -768,7 +768,7 @@ AnovaRepeatedMeasures <- function(jaspResults, dataset = NULL, options) {
                       df2 = r[[1]]$Df[2],
                       p=r[[1]]$`Pr(>F)`[1],
                       ".isNewGroup" = i == 1,
-                      VovkSellkeMPR = VovkSellkeMPR(r[[1]]$`Pr(>F)`[1]))
+                      vovkSellke = VovkSellkeMPR(r[[1]]$`Pr(>F)`[1]))
 
     rmAnovaLevenesTable$addRows(row)
 
@@ -863,18 +863,18 @@ AnovaRepeatedMeasures <- function(jaspResults, dataset = NULL, options) {
 }
 
 .rmAnovaPostHocTable <- function(rmAnovaContainer, dataset, longData, options, ready) {
-  if(!is.null(rmAnovaContainer[["postHocStandardContainer"]]) || length(options$postHocTestsVariables) ==0)
+  if(!is.null(rmAnovaContainer[["postHocStandardContainer"]]) || length(options$postHocTerms) ==0)
     return()
 
   postHocContainer <- createJaspContainer(title = gettext("Post Hoc Tests"))
-  postHocContainer$dependOn(c("postHocTestsVariables", "postHocTestEffectSize", "postHocTestsBonferroni",
-                              "postHocTestsHolm", "postHocTestsScheffe", "postHocTestsTukey",
-                              "postHocFlagSignificant", "confidenceIntervalsPostHoc",
-                              "confidenceIntervalIntervalPostHoc", "postHocTestPooledError"))
+  postHocContainer$dependOn(c("postHocTerms", "postHocEffectSize", "postHocCorrectionBonferroni",
+                              "postHocCorrectionHolm", "postHocCorrectionScheffe", "postHocCorrectionTukey",
+                              "postHocSignificanceFlag", "postHocCi",
+                              "postHocCiLevel", "postHocPooledError"))
 
   rmAnovaContainer[["postHocStandardContainer"]] <- postHocContainer
 
-  postHocVariables <- unlist(options$postHocTestsVariables, recursive = FALSE)
+  postHocVariables <- unlist(options$postHocTerms, recursive = FALSE)
   postHocVariablesListV <- unname(lapply(postHocVariables, .v))
   variables <- unname(sapply(postHocVariables, function(x) paste(.v(x), collapse = ":")))
 
@@ -899,10 +899,10 @@ AnovaRepeatedMeasures <- function(jaspResults, dataset = NULL, options) {
   for (var in variables) {
 
     resultPostHoc <- summary(pairs(referenceGrid[[var]], adjust="bonferroni"),
-                          infer = TRUE, level = options$confidenceIntervalIntervalPostHoc)
+                          infer = TRUE, level = options$postHocCiLevel)
 
     numberOfLevels <- nrow(as.data.frame(referenceGrid[[var]]))
-    bonfAdjustCIlevel <- .computeBonferroniConfidence(options$confidenceIntervalIntervalPostHoc,
+    bonfAdjustCIlevel <- .computeBonferroniConfidence(options$postHocCiLevel,
                                                       numberOfLevels = numberOfLevels)
 
     effectSizeResult <- as.data.frame(emmeans::eff_size(referenceGrid[[var]],
@@ -929,7 +929,7 @@ AnovaRepeatedMeasures <- function(jaspResults, dataset = NULL, options) {
 
     if (any(var == .v(allNames))) {     ## If the variable is a repeated measures factor
 
-      if (!options$postHocTestPooledError && balancedDesign) {
+      if (!options$postHocPooledError && balancedDesign) {
 
        # Loop over all the levels within factor and do pairwise t.tests on them
         for (compIndex in seq_along(comparisons)) {
@@ -954,15 +954,15 @@ AnovaRepeatedMeasures <- function(jaspResults, dataset = NULL, options) {
         resultPostHoc[["bonferroni"]] <- p.adjust(resultPostHoc[["p.value"]], method = "bonferroni")
         resultPostHoc[["holm"]] <- p.adjust(resultPostHoc[["p.value"]], method = "holm")
 
-      } else if (!options$postHocTestPooledError) {
+      } else if (!options$postHocPooledError) {
         postHocContainer$setError(gettext("Unpooled error term only allowed in balanced designs."))
         return()
       }
 
       resultPostHoc[["scheffe"]] <- "."
       resultPostHoc[["tukey"]] <-  "."
-      if (options$postHocTestsScheffe || options$postHocTestsTukey) {
-        cors <- paste(c("Tukey", "Scheffe")[c(options$postHocTestsTukey, options$postHocTestsScheffe)], collapse = " and ")
+      if (options$postHocCorrectionScheffe || options$postHocCorrectionTukey) {
+        cors <- paste(c("Tukey", "Scheffe")[c(options$postHocCorrectionTukey, options$postHocCorrectionScheffe)], collapse = " and ")
 
         postHocContainer[[var]]$addFootnote(gettextf("%s corrected p-values are not appropriate for repeated measures post-hoc tests (Maxwell, 1980; Field, 2012).", cors))
       }
@@ -975,7 +975,7 @@ AnovaRepeatedMeasures <- function(jaspResults, dataset = NULL, options) {
 
     if (nrow(resultPostHoc) > 1)
       postHocContainer[[var]]$addFootnote(.getCorrectionFootnoteAnova(resultPostHoc,
-                                                                      options$confidenceIntervalsPostHoc))
+                                                                      options$postHocCi))
 
     avFootnote <- attr(resultPostHoc, "mesg")[grep(attr(resultPostHoc, "mesg"), pattern = "Results are averaged")]
     if (length(avFootnote) != 0) {
@@ -989,7 +989,7 @@ AnovaRepeatedMeasures <- function(jaspResults, dataset = NULL, options) {
     postHocContainer[[var]]$setData(resultPostHoc)
 
 
-    if (options$postHocFlagSignificant)
+    if (options$postHocSignificanceFlag)
       .anovaAddSignificanceSigns(someTable = postHocContainer[[var]],
                                  allPvalues = resultPostHoc[c("bonferroni", "scheffe", "tukey", "holm")],
                                  resultRowNames = rownames(resultPostHoc))
@@ -1052,7 +1052,7 @@ AnovaRepeatedMeasures <- function(jaspResults, dataset = NULL, options) {
 
   postHocTable$addColumnInfo(name="t.ratio", title=gettext("t"), type="number")
 
-  if (options$postHocTypeStandardEffectSize) {
+  if (options$postHocTypeStandardEffectSize || options$postHocEffectSize) {
     postHocTable$addColumnInfo(name="cohenD", title=gettext("Cohen's d"), type="number")
 
     if (isFALSE(options$postHocPooledError))
@@ -1091,8 +1091,8 @@ AnovaRepeatedMeasures <- function(jaspResults, dataset = NULL, options) {
     return()
 
   contrastContainer <- createJaspContainer(title = gettext("Contrast Tables"))
-  contrastContainer$dependOn(c("contrasts", "contrastAssumeEqualVariance", "confidenceIntervalIntervalContrast",
-                               "confidenceIntervalsContrast", "customContrasts"))
+  contrastContainer$dependOn(c("contrasts", "contrastEqualVariance", "contrastCiLevel",
+                               "contrastCi", "customContrasts"))
 
   for (contrast in options$contrasts) {
 
@@ -1179,10 +1179,10 @@ AnovaRepeatedMeasures <- function(jaspResults, dataset = NULL, options) {
         contrastContainer[[contrastContainerName]][["contrastTable"]]$addFootnote(
           message = gettextf("Results are averaged over the levels of: %s", paste(.unv(contrastResult@misc$avgd.over), collapse = ", ")))
 
-      contrastResult <- cbind(contrastResult, confint(contrastResult, level = options$confidenceIntervalIntervalContrast)[,5:6])
+      contrastResult <- cbind(contrastResult, confint(contrastResult, level = options$contrastCiLevel)[,5:6])
       contrastResult[["Comparison"]] <- .unv(contrastResult[["contrast"]])
 
-      if (options$contrastAssumeEqualVariance == FALSE && contrast$variable %in% unlist(options$withinModelTerms) &&
+      if (options$contrastEqualVariance == FALSE && contrast$variable %in% unlist(options$withinModelTerms) &&
           length(contrast$variable) == 1 && contrast$contrast != "custom") {
 
         newDF <- do.call(data.frame, tapply(longData[[.BANOVAdependentName]], longData[[.v(contrast$variable)]], cbind))
@@ -1205,7 +1205,7 @@ AnovaRepeatedMeasures <- function(jaspResults, dataset = NULL, options) {
         contrastResult[["SE"]]      <- sapply(allTestResults, function(x) x[["estimate"]] /  x[["statistic"]])
         contrastResult[["p.value"]] <- sapply(allTestResults, function(x) x[["p.value"]])
 
-      } else if (options$contrastAssumeEqualVariance == FALSE) {
+      } else if (options$contrastEqualVariance == FALSE) {
 
         contrastContainer[[contrastContainerName]]$setError(gettext("Unequal variances only available for main effects of within subjects factors"))
         return()
@@ -1227,16 +1227,16 @@ AnovaRepeatedMeasures <- function(jaspResults, dataset = NULL, options) {
 }
 
 .rmAnovaMarginalMeansTable <- function(rmAnovaContainer, dataset, options, ready) {
-  if (!is.null(rmAnovaContainer[["marginalMeansContainer"]]) || length(options$marginalMeansTerms) == 0)
+  if (!is.null(rmAnovaContainer[["marginalMeansContainer"]]) || length(options$marginalMeanTerms) == 0)
     return ()
 
   marginalMeansContainer <- createJaspContainer(title = gettext("Marginal Means"))
-  marginalMeansContainer$dependOn(c("marginalMeansTerms",  "marginalMeanComparedToZero", "marginalMeansCIAdjustment",
-                                    "marginalMeansBootstrapping", "marginalMeansBootstrappingReplicates"))
+  marginalMeansContainer$dependOn(c("marginalMeanTerms",  "marginalMeanComparedToZero", "marginalMeanCiCorrection",
+                                    "marginalMeanBootstrap", "marginalMeanBootstrapSamples"))
 
   rmAnovaContainer[["marginalMeansContainer"]] <- marginalMeansContainer
 
-  marginalTerms <- unlist(options$marginalMeansTerms, recursive = FALSE)
+  marginalTerms <- unlist(options$marginalMeanTerms, recursive = FALSE)
 
 
   for (term in marginalTerms) {
@@ -1245,7 +1245,7 @@ AnovaRepeatedMeasures <- function(jaspResults, dataset = NULL, options) {
     if (any(term %in% unlist(options$withinModelTerms))) dfType <- "number" else dfType <- "integer"
     marginalMeansContainer[[paste0(.v(term), collapse = ":")]] <- .createMarginalMeansTableAnova(thisVarName, options,
                                                                                                  individualTerms,
-                                                                                                 options$marginalMeansBootstrapping,
+                                                                                                 options$marginalMeanBootstrap,
                                                                                                  dfType = dfType)
   }
 
@@ -1260,9 +1260,9 @@ AnovaRepeatedMeasures <- function(jaspResults, dataset = NULL, options) {
 
     formula <- as.formula(paste("~", termBase64))
 
-    if(options$marginalMeansCIAdjustment == "bonferroni") {
+    if(options$marginalMeanCiCorrection == "bonferroni") {
       adjMethod <- "bonferroni"
-    } else if(options$marginalMeansCIAdjustment == "sidak") {
+    } else if(options$marginalMeanCiCorrection == "sidak") {
       adjMethod <- "sidak"
     } else {
       adjMethod <- "none"
@@ -1280,15 +1280,15 @@ AnovaRepeatedMeasures <- function(jaspResults, dataset = NULL, options) {
 
 
     ### Bootstrapping
-    if (options$marginalMeansBootstrapping) {
+    if (options$marginalMeanBootstrap) {
 
-      startProgressbar(options[["marginalMeansBootstrappingReplicates"]],
+      startProgressbar(options[["marginalMeanBootstrapSamples"]],
                        label = gettext("Bootstrapping Marginal Means"))
 
       nRows <- nrow(marginalResult)
 
       bootstrapMarginalMeans <- try(boot::boot(data = dataset, statistic = .bootstrapMarginalMeansRmAnova,
-                                               R = options[["marginalMeansBootstrappingReplicates"]],
+                                               R = options[["marginalMeanBootstrapSamples"]],
                                                options = options,
                                                nRows = nRows,
                                                termLength = length(term),
@@ -1638,34 +1638,34 @@ AnovaRepeatedMeasures <- function(jaspResults, dataset = NULL, options) {
 }
 
 .rmAnovaSimpleEffects <- function(rmAnovaContainer, dataset, longData, options, ready) {
-  if (!is.null(rmAnovaContainer[["simpleEffectsContainer"]]) || identical(options$simpleFactor, "") ||
-      identical(options$moderatorFactorOne, ""))
+  if (!is.null(rmAnovaContainer[["simpleEffectsContainer"]]) || identical(options$simpleMainEffectFactor, "") ||
+      identical(options$simpleMainEffectModeratorFactorOne, ""))
     return()
 
   rmAnovaContainer[["simpleEffectsContainer"]] <- createJaspContainer(title = gettext("Simple Main Effects"),
-                                                                      dependencies = c("simpleFactor",
-                                                                                       "moderatorFactorOne",
-                                                                                       "moderatorFactorTwo",
-                                                                                       "poolErrorTermSimpleEffects"))
+                                                                      dependencies = c("simpleMainEffectFactor",
+                                                                                       "simpleMainEffectModeratorFactorOne",
+                                                                                       "simpleMainEffectModeratorFactorTwo",
+                                                                                       "simpleMainEffectErrorTermPooled"))
 
-  simpleEffectsTable <- createJaspTable(title = gettextf("Simple Main Effects - %s", options$simpleFactor))
+  simpleEffectsTable <- createJaspTable(title = gettextf("Simple Main Effects - %s", options$simpleMainEffectFactor))
   rmAnovaContainer[["simpleEffectsContainer"]][["simpleEffectsTable"]] <- simpleEffectsTable
 
   # the simple factor must appear in the model terms, but the moderator factors may be missing.
   withinModelTerms <- unique(unlist(lapply(options[["withinModelTerms"]], `[[`, "components"), use.names = FALSE))
   betweenModelTerms <- unique(unlist(lapply(options[["betweenModelTerms"]], `[[`, "components"), use.names = FALSE))
 
-  if (!(options[["simpleFactor"]] %in% c(withinModelTerms, betweenModelTerms))) {
+  if (!(options[["simpleMainEffectFactor"]] %in% c(withinModelTerms, betweenModelTerms))) {
     rmAnovaContainer[["simpleEffectsContainer"]]$setError(gettext("Moderator factors must also appear in the model terms!"))
     return()
   }
 
-  moderatorTerms <- c(options$moderatorFactorOne, options$moderatorFactorTwo[!identical(options$moderatorFactorTwo, "")])
+  moderatorTerms <- c(options$simpleMainEffectModeratorFactorOne, options$simpleMainEffectModeratorFactorTwo[!identical(options$simpleMainEffectModeratorFactorTwo, "")])
   nMods <- length(moderatorTerms)
-  simpleFactor <- options[['simpleFactor']]
-  simpleFactorBase64 <- simpleFactor
+  simpleMainEffectFactor <- options[['simpleMainEffectFactor']]
+  simpleMainEffectFactorBase64 <- simpleMainEffectFactor
 
-  simpleEffectsTable[["title"]] <- gettextf("Simple Main Effects - %s", options$simpleFactor)
+  simpleEffectsTable[["title"]] <- gettextf("Simple Main Effects - %s", options$simpleMainEffectFactor)
 
   simpleEffectsTable$addColumnInfo(name = "modOne", title = gettextf("Level of %s", moderatorTerms[1]),
                                    type = "string", combine = TRUE)
@@ -1712,20 +1712,20 @@ AnovaRepeatedMeasures <- function(jaspResults, dataset = NULL, options) {
   fullResidualTable <- rmAnovaContainer[["anovaResult"]][["object"]][["residualTable"]][["None"]]
 
   isMixedAnova <-   length(options[['betweenModelTerms']]) > 0
-  isSimpleFactorWithin <- !simpleFactor %in% unlist(options[['betweenModelTerms']] )
+  isSimpleMainEffectFactorWithin <- !simpleMainEffectFactor %in% unlist(options[['betweenModelTerms']] )
   isModeratorOneWithin <- !moderatorTerms[1] %in% unlist(options[['betweenModelTerms']] )
   isModeratorTwoWithin <- !moderatorTerms[2] %in% unlist(options[['betweenModelTerms']] )
 
 
-  if (isMixedAnova && !isSimpleFactorWithin) {
+  if (isMixedAnova && !isSimpleMainEffectFactorWithin) {
 
     fullAnovaMS <- fullResidualTable["BetweenResidualResults", "Mean Sq"]
     fullAnovaDf <- fullResidualTable["BetweenResidualResults", "num Df"]
 
   } else {
 
-    fullAnovaMS <- fullResidualTable[simpleFactorBase64, "Mean Sq"]
-    fullAnovaDf <- fullResidualTable[simpleFactorBase64, "num Df"]
+    fullAnovaMS <- fullResidualTable[simpleMainEffectFactorBase64, "Mean Sq"]
+    fullAnovaDf <- fullResidualTable[simpleMainEffectFactorBase64, "num Df"]
 
   }
 
@@ -1761,7 +1761,7 @@ AnovaRepeatedMeasures <- function(jaspResults, dataset = NULL, options) {
       simpleEffectResult[[i, ".isNewGroup"]] <- TRUE
 
     if (nrow(simpleDataset) < 2 ||
-        nrow(unique(simpleDataset[simpleFactorBase64])) <  nrow(unique(longData[simpleFactorBase64])) ||
+        nrow(unique(simpleDataset[simpleMainEffectFactorBase64])) <  nrow(unique(longData[simpleMainEffectFactorBase64])) ||
         length(unique(simpleDataset[["JaspColumn_.subject._Encoded"]])) == 1) {
 
       emptyCaseIndices <- c(emptyCaseIndices, i)
@@ -1776,12 +1776,12 @@ AnovaRepeatedMeasures <- function(jaspResults, dataset = NULL, options) {
 
       rmAnovaContainer[["simpleEffectsContainer"]][["model"]] <- NULL
 
-      if (!options$poolErrorTermSimpleEffects) {
+      if (!options$simpleMainEffectErrorTermPooled) {
         fullAnovaMS <-  anovaResult["Residuals", "Mean Sq"]
         fullAnovaDf <-  anovaResult["Residuals", "Df"]
       }
 
-      anovaResult <- anovaResult[simpleFactorBase64, ]
+      anovaResult <- anovaResult[simpleMainEffectFactorBase64, ]
       df <- anovaResult[["Df"]]
       MS <- anovaResult[["Mean Sq"]] <- anovaResult[["Sum Sq"]] /  df
       fStat <- MS / fullAnovaMS
@@ -1789,9 +1789,9 @@ AnovaRepeatedMeasures <- function(jaspResults, dataset = NULL, options) {
       thisRow <- c(anovaResult[["Sum Sq"]], MS, df, fStat, p)
     } else {
 
-      anovaResult <-  .rmAnovaComputeResults(simpleDataset, simpleOptions, returnResultsEarly = TRUE)$model[simpleFactorBase64, ]
+      anovaResult <-  .rmAnovaComputeResults(simpleDataset, simpleOptions, returnResultsEarly = TRUE)$model[simpleMainEffectFactorBase64, ]
 
-      if (!options$poolErrorTermSimpleEffects) {
+      if (!options$simpleMainEffectErrorTermPooled) {
         fullAnovaMS <-  anovaResult[["Error SS"]] / anovaResult[["den Df"]]
         fullAnovaDf <-  anovaResult[["den Df"]]
       }

--- a/R/commonAnovaBayesian.R
+++ b/R/commonAnovaBayesian.R
@@ -1586,8 +1586,8 @@ BANOVAcomputMatchedInclusion <- function(effectNames, effects.matrix, interactio
     descriptivesPlotContainer$dependOn(c("dependent", "descriptivePlotCi", "descriptivePlotCiLevel"))
 
   } else {
-    plotErrorBars <- options$plotErrorBars
-    errorBarType  <- if(options$descriptivePlotErrorBarType == "ci") "confindenceInterval" else "se"
+    plotErrorBars <- options$descriptivePlotErrorBar
+    errorBarType  <- if(options$descriptivePlotErrorBarType == "ci") "confidenceInterval" else "se"
     conf.interval <- options$descriptivePlotCiLevel
     descriptivesPlotContainer$dependOn(c("dependent", "plotErrorBars", "descriptivePlotErrorBarType", "descriptivePlotCiLevel",
                                          "descriptivePlotErrorBarPooled"))

--- a/R/commonAnovaBayesian.R
+++ b/R/commonAnovaBayesian.R
@@ -1435,6 +1435,30 @@ BANOVAcomputMatchedInclusion <- function(effectNames, effects.matrix, interactio
 .BANOVAdescriptives <- function(jaspResults, dataset, options, errors, analysisType, ready = TRUE, position = 9001) {
   if (!ready)
     return()
+
+  # temporary rename options: Get rid of this once BANOVAs renaming options are also done
+  if(!is.null(options[["descriptivePlotHorizontalAxis"]])) {
+    options[["plotHorizontalAxis"]]         <- options[["descriptivePlotHorizontalAxis"]]
+    options[["plotSeparateLines"]]          <- options[["descriptivePlotSeparateLines"]]
+    options[["plotSeparatePlots"]]          <- options[["descriptivePlotSeparatePlot"]]
+    options[["plotErrorBars"]]              <- options[["descriptivePlotErrorBar"]]
+    options[["confidenceIntervalInterval"]] <- options[["descriptivePlotCiLevel"]]
+
+    options[["errorBarType"]] <- switch(
+      options[["descriptivePlotErrorBarType"]],
+      ci = "confidenceInterval",
+      se = "standardError"
+    )
+
+    options[["rainCloudPlotsVariables"]]         <- options[["rainCloudAvailableFactors"]]
+    options[["rainCloudPlotsHorizontalAxis"]]    <- options[["rainCloudHorizontalAxis"]]
+    options[["rainCloudPlotsSeparatePlots"]]     <- options[["rainCloudSeparatePlots"]]
+    options[["rainCloudPlotsHorizontalDisplay"]] <- options[["rainCloudHorizontalDisplay"]]
+  }
+
+
+
+
   # the main use of this function is that descriptives can now be reused for the frequentist ANOVAs
   # without the container, the position could mess things up
   descriptivesContainer <- jaspResults[["descriptivesContainer"]]

--- a/R/commonOrdinalRestrictions.R
+++ b/R/commonOrdinalRestrictions.R
@@ -242,7 +242,7 @@
 
   model <- list(
     fit                       = fit,
-    modelName                 = modelName,
+    name                      = modelName,
     summary                   = restrictedModelOption[["summary"]],
     informedHypothesisTest    = restrictedModelOption[["informedHypothesisTest"]],
     marginalMean              = restrictedModelOption[["marginalMean"]],
@@ -337,7 +337,7 @@
   }
 
   if(!isTryError(modelComparison)) {
-    modelNames <- vapply(models[["restricted"]], "[[", character(1), "modelName")
+    modelNames <- .aorGetModelNames(models[["restricted"]])
     names(modelNames) <- modelNames
     modelNames <- switch(comparison,
                          unconstrained = c(modelNames, unconstrained = gettext("Unconstrained")),

--- a/inst/Description.qml
+++ b/inst/Description.qml
@@ -7,7 +7,7 @@ Description
 	title		: qsTr("ANOVA")
 	icon		: "analysis-classical-anova.svg"
 	description	: qsTr("Evaluate the difference between multiple means")
-	version		: "0.16.3"
+	version		: "0.16.4"
 	author		: "JASP Team"
 	maintainer	: "JASP Team <info@jasp-stats.org>"
 	website		: "jasp-stats.org"

--- a/inst/Upgrades.qml
+++ b/inst/Upgrades.qml
@@ -367,4 +367,157 @@ Upgrades
 		ChangeRename {	from: "kruskalVariablesAvailable";	to: "kruskalWallisAvailableFactors"	}
 		ChangeRename {	from: "kruskalVariablesAssigned";	to: "kruskalWallisFactors"			}
 	}
+
+	Upgrade
+	{
+		functionName:		"AnovaRepeatedMeasures"
+		fromVersion:		"0.16.3"
+		toVersion:			"0.16.4"
+
+		// Display.qml
+		ChangeRename {	from: "VovkSellkeMPR";	to: "vovkSellke"	}
+
+		// Model section
+		ChangeRename {	from: "useMultivariateModelFollowup";	to: "multivariateModelFollowup"	}
+
+		// AssumptionChecks.qml
+		ChangeRename {	from: "sphericityNone";					to: "sphericityCorrectionNone"				}
+		ChangeRename {	from: "sphericityGreenhouseGeisser";	to: "sphericityCorrectionGreenhouseGeisser"	}
+		ChangeRename {	from: "sphericityHuynhFeldt";			to: "sphericityCorrectionHuynhFeldt"		}
+
+
+		// Contrasts.qml
+		ChangeRename {	from: "contrastAssumeEqualVariance";			to: "contrastEqualVariance"		}
+		ChangeRename {	from: "confidenceIntervalsContrast";			to: "contrastCi"				}
+		ChangeRename {	from: "confidenceIntervalIntervalContrast";		to: "contrastCiLevel"			}
+
+		// OrderRestrictions.qml
+		ChangeRename {	from: "restrictedIncludeIntercept";					to: "restrictedInterceptInclusion"					}
+		ChangeRename {	from: "restrictedModelShowAvailableCoefficients";	to: "restrictedAvailableCoefficients"				}
+		ChangeRename {	from: "restrictedModelSummaryByDefault";			to: "restrictedModelSummaryForAllModels"			}
+		ChangeRename {	from: "restrictedMarginalMeansByDefault";			to: "restrictedMarginalMeanForAllModels"			}
+		ChangeRename {	from: "restrictedInformedHypothesisTestByDefault";	to: "restrictedInformedHypothesisTestForAllModels"	}
+
+		// restrictedModels is an array of option lists so we need to change the option names for each model
+		ChangeJS
+		{
+			name: "restrictedModels"
+			jsFunction: function(options)
+			{
+				let newModels = options["restrictedModels"].map(model => {
+					let newModel = {};
+					newModel.informedHypothesisTest	= model.informedHypothesisTest;
+					newModel.marginalMean			= model.marginalMeans;
+					newModel.summary				= model.modelSummary;
+					newModel.name					= model.modelName;
+					newModel.syntax					= model.restrictionSyntax;
+
+					return newModel ;
+				});
+
+				return newModels;
+			}
+		}
+
+		ChangeRename {	from: "restrictedModelComparisonHighlightCoefficients";		to: "restrictedModelComparisonCoefficientsHighlight"	}
+
+		ChangeRename {	from: "restrictedSE";	to: "restrictedHeterogeneityCorrection"	}
+
+		ChangeJS
+		{
+			name: "restrictedHeterogeneityCorrection"
+			jsFunction: function(options)
+			{
+				switch(options["restrictedHeterogeneityCorrection"])
+				{
+					case "standard":	return "none";
+					case "HC0":			return "huberWhite0";
+					case "HC1":			return "huberWhite1";
+					case "HC2":			return "huberWhite2";
+					case "HC3":			return "huberWhite3";
+					case "HC4":			return "huberWhite4";
+					case "HC4m":		return "huberWhite4m";
+					case "HC5":			return "huberWhite5";
+					default:			return options["restrictedHeterogeneityCorrection"];
+				}
+			}
+		}
+
+		ChangeRename {	from: "restrictedBootstrapping";								to: "restrictedBootstrap"			}
+		ChangeRename {	from: "restrictedBootstrappingReplicates";						to: "restrictedBootstrapSamples"	}
+		ChangeRename {	from: "restrictedBootstrappingConfidenceIntervalLevel";			to: "restrictedBootstrapCiLevel"	}
+
+		ChangeRename {	from: "restrictedModelMarginalMeansTerms";	to: "restrictedMarginalMeanTerms"	}
+
+		// PostHoc section
+		ChangeRename {	from: "postHocTestsAvailable";					to: "postHocAvailableTerms"					}
+		ChangeRename {	from: "postHocTestsVariables";					to: "postHocTerms"							}
+		ChangeRename {	from: "postHocTestEffectSize";					to: "postHocEffectSize"						}
+		ChangeRename {	from: "postHocTestPooledError";					to: "postHocPooledError"			}
+
+		ChangeRename {	from: "postHocTestsHolm";						to: "postHocCorrectionHolm"					}
+		ChangeRename {	from: "postHocTestsBonferroni";					to: "postHocCorrectionBonferroni"			}
+		ChangeRename {	from: "postHocTestsTukey";						to: "postHocCorrectionTukey"				}
+		ChangeRename {	from: "postHocTestsScheffe";					to: "postHocCorrectionScheffe"				}
+
+		// PostHocDiplay.qml
+		ChangeRename {	from: "confidenceIntervalsPostHoc";			to: "postHocCi"					}
+		ChangeRename {	from: "confidenceIntervalIntervalPostHoc";	to: "postHocCiLevel"			}
+		ChangeRename {	from: "postHocFlagSignificant";				to: "postHocSignificanceFlag"	}
+
+		// DescriptivePlots.qml
+		ChangeRename {	from: "descriptivePlotsVariables";	to: "descriptivePlotAvailableFactors"	}
+		ChangeRename {	from: "plotHorizontalAxis";			to: "descriptivePlotHorizontalAxis"		}
+		ChangeRename {	from: "plotSeparateLines";			to: "descriptivePlotSeparateLines"		}
+		ChangeRename {	from: "plotSeparatePlots";			to: "descriptivePlotSeparatePlot"		}
+		ChangeRename {	from: "plotErrorBars";				to: "descriptivePlotErrorBar"			}
+		ChangeRename {	from: "errorBarType";				to: "descriptivePlotErrorBarType"		}
+
+		ChangeJS
+		{
+			name: "descriptivePlotErrorBarType"
+			jsFunction: function(options)
+			{
+				switch(options["descriptivePlotErrorBarType"])
+				{
+					case "confidenceInterval":	return "ci";
+					case "standardError":		return "se";
+					default:					return options["descriptivePlotErrorBarType"];
+				}
+			}
+		}
+
+		ChangeRename {	from: "confidenceIntervalInterval";		to: "descriptivePlotCiLevel"	}
+
+		ChangeRename {	from: "labelYAxis";					to: "descriptivePlotYAxisLabel"		}
+		ChangeRename {	from: "usePooledStandErrorCI";		to: "descriptivePlotErrorBarPooled"	}
+
+
+		// RainCloudPlots.qml
+		ChangeRename {	from: "rainCloudPlotsVariables";			to: "rainCloudAvailableFactors"		}
+		ChangeRename {	from: "rainCloudPlotsHorizontalAxis";		to: "rainCloudHorizontalAxis"		}
+		ChangeRename {	from: "rainCloudPlotsSeparatePlots";		to: "rainCloudSeparatePlots"		}
+		ChangeRename {	from: "rainCloudPlotsLabelYAxis";			to: "rainCloudYAxisLabel"			}
+
+
+		// MarginalMeans.qml
+		ChangeRename {	from: "marginalMeansTermsAvailable";			to: "marginalMeanAvailableTerms"	}
+		ChangeRename {	from: "marginalMeansTerms";						to: "marginalMeanTerms"				}
+		ChangeRename {	from: "marginalMeansBootstrapping";				to: "marginalMeanBootstrap"			}
+		ChangeRename {	from: "marginalMeansBootstrappingReplicates";	to: "marginalMeanBootstrapSamples"	}
+		ChangeRename {	from: "marginalMeansCompareMainEffects";		to: "marginalMeanComparedToZero"	}
+		ChangeRename {	from: "marginalMeansCIAdjustment";				to: "marginalMeanCiCorrection"		}
+
+		// SimpleMainEffects
+		ChangeRename {	from: "effectsVariables";		to: "simpleMainEffectAvailableFactors"		}
+		ChangeRename {	from: "simpleFactor";			to: "simpleMainEffectFactor"				}
+		ChangeRename {	from: "moderatorFactorOne";		to: "simpleMainEffectModeratorFactorOne"	}
+		ChangeRename {	from: "moderatorFactorTwo";		to: "simpleMainEffectModeratorFactorTwo"	}
+
+		ChangeRename {	from: "poolErrorTermSimpleEffects";		to: "simpleMainEffectErrorTermPooled"	}
+
+
+		// Nonparametrics
+		ChangeRename {	from: "kruskalVariablesAvailable";	to: "friedmanAvailableFactors"		}
+	}
 }

--- a/inst/Upgrades.qml
+++ b/inst/Upgrades.qml
@@ -301,7 +301,7 @@ Upgrades
 		ChangeRename {	from: "postHocTestsAvailable";					to: "postHocAvailableTerms"					}
 		ChangeRename {	from: "postHocTestsVariables";					to: "postHocTerms"							}
 		ChangeRename {	from: "postHocTestsTypeStandard";				to: "postHocTypeStandard"					}
-		ChangeRename {	from: "postHocBootstrapping";					to: "postHocTypeStandardBootstrap"			}
+		ChangeRename {	from: "postHocTestsBootstrapping";				to: "postHocTypeStandardBootstrap"			}
 		ChangeRename {	from: "postHocTestsBootstrappingReplicates";	to: "postHocTypeStandardBootstrapSamples"	}
 		ChangeRename {	from: "postHocTestEffectSize";					to: "postHocTypeStandardEffectSize"			}
 		ChangeRename {	from: "postHocTestsTypeGames";					to: "postHocTypeGames"						}

--- a/inst/Upgrades.qml
+++ b/inst/Upgrades.qml
@@ -201,6 +201,7 @@ Upgrades
 		ChangeRename {	from: "rainCloudPlotsVariables";			to: "rainCloudAvailableFactors"		}
 		ChangeRename {	from: "rainCloudPlotsHorizontalAxis";		to: "rainCloudHorizontalAxis"		}
 		ChangeRename {	from: "rainCloudPlotsSeparatePlots";		to: "rainCloudSeparatePlots"		}
+		ChangeRename {	from: "rainCloudPlotsHorizontalDisplay";	to: "rainCloudHorizontalDisplay"	}
 
 
 		// MarginalMeans.qml
@@ -345,6 +346,7 @@ Upgrades
 		ChangeRename {	from: "rainCloudPlotsVariables";			to: "rainCloudAvailableFactors"		}
 		ChangeRename {	from: "rainCloudPlotsHorizontalAxis";		to: "rainCloudHorizontalAxis"		}
 		ChangeRename {	from: "rainCloudPlotsSeparatePlots";		to: "rainCloudSeparatePlots"		}
+		ChangeRename {	from: "rainCloudPlotsHorizontalDisplay";	to: "rainCloudHorizontalDisplay"	}
 
 
 		// MarginalMeans.qml

--- a/inst/Upgrades.qml
+++ b/inst/Upgrades.qml
@@ -520,4 +520,72 @@ Upgrades
 		// Nonparametrics
 		ChangeRename {	from: "kruskalVariablesAvailable";	to: "friedmanAvailableFactors"		}
 	}
+
+	Upgrade
+	{
+		functionName:		"AnovaBayesian"
+		fromVersion:		"0.16.3"
+		toVersion:			"0.16.4"
+
+		// RainCloudPlots.qml
+		ChangeRename {	from: "rainCloudPlotsVariables";			to: "rainCloudAvailableFactors"		}
+		ChangeRename {	from: "rainCloudPlotsHorizontalAxis";		to: "rainCloudHorizontalAxis"		}
+		ChangeRename {	from: "rainCloudPlotsSeparatePlots";		to: "rainCloudSeparatePlots"		}
+		ChangeRename {	from: "rainCloudPlotsHorizontalDisplay";	to: "rainCloudHorizontalDisplay"	}
+
+		// DescriptivePlots.qml
+		ChangeRename {	from: "descriptivePlotsVariables";		to: "descriptivePlotAvailableFactors"	}
+		ChangeRename {	from: "plotHorizontalAxis";				to: "descriptivePlotHorizontalAxis"		}
+		ChangeRename {	from: "plotSeparateLines";				to: "descriptivePlotSeparateLines"		}
+		ChangeRename {	from: "plotSeparatePlots";				to: "descriptivePlotSeparatePlot"		}
+
+		ChangeRename {	from: "plotCredibleInterval";			to: "descriptivePlotCi"					}
+		ChangeRename {	from: "plotCredibleIntervalInterval";	to: "descriptivePlotCiLevel"			}
+	}
+
+	Upgrade
+	{
+		functionName:		"AncovaBayesian"
+		fromVersion:		"0.16.3"
+		toVersion:			"0.16.4"
+
+		// RainCloudPlots.qml
+		ChangeRename {	from: "rainCloudPlotsVariables";			to: "rainCloudAvailableFactors"		}
+		ChangeRename {	from: "rainCloudPlotsHorizontalAxis";		to: "rainCloudHorizontalAxis"		}
+		ChangeRename {	from: "rainCloudPlotsSeparatePlots";		to: "rainCloudSeparatePlots"		}
+		ChangeRename {	from: "rainCloudPlotsHorizontalDisplay";	to: "rainCloudHorizontalDisplay"	}
+
+		// DescriptivePlots.qml
+		ChangeRename {	from: "descriptivePlotsVariables";		to: "descriptivePlotAvailableFactors"	}
+		ChangeRename {	from: "plotHorizontalAxis";				to: "descriptivePlotHorizontalAxis"		}
+		ChangeRename {	from: "plotSeparateLines";				to: "descriptivePlotSeparateLines"		}
+		ChangeRename {	from: "plotSeparatePlots";				to: "descriptivePlotSeparatePlot"		}
+
+		ChangeRename {	from: "plotCredibleInterval";			to: "descriptivePlotCi"					}
+		ChangeRename {	from: "plotCredibleIntervalInterval";	to: "descriptivePlotCiLevel"			}
+	}
+
+	Upgrade
+	{
+		functionName:		"AnovaRepeatedMeasuresBayesian"
+		fromVersion:		"0.16.3"
+		toVersion:			"0.16.4"
+
+		// RainCloudPlots.qml
+		ChangeRename {	from: "rainCloudPlotsVariables";			to: "rainCloudAvailableFactors"		}
+		ChangeRename {	from: "rainCloudPlotsHorizontalAxis";		to: "rainCloudHorizontalAxis"		}
+		ChangeRename {	from: "rainCloudPlotsSeparatePlots";		to: "rainCloudSeparatePlots"		}
+		ChangeRename {	from: "rainCloudPlotsLabelYAxis";			to: "rainCloudYAxisLabel"			}
+
+		// DescriptivePlots.qml
+		ChangeRename {	from: "descriptivePlotsVariables";		to: "descriptivePlotAvailableFactors"	}
+		ChangeRename {	from: "plotHorizontalAxis";				to: "descriptivePlotHorizontalAxis"		}
+		ChangeRename {	from: "plotSeparateLines";				to: "descriptivePlotSeparateLines"		}
+		ChangeRename {	from: "plotSeparatePlots";				to: "descriptivePlotSeparatePlot"		}
+
+		ChangeRename {	from: "plotCredibleInterval";			to: "descriptivePlotCi"					}
+		ChangeRename {	from: "plotCredibleIntervalInterval";	to: "descriptivePlotCiLevel"			}
+
+		ChangeRename {	from: "labelYAxis";						to: "descriptivePlotYAxisLabel"			}
+	}
 }

--- a/inst/Upgrades.qml
+++ b/inst/Upgrades.qml
@@ -376,6 +376,7 @@ Upgrades
 
 		// Display.qml
 		ChangeRename {	from: "VovkSellkeMPR";	to: "vovkSellke"	}
+		ChangeRename {	from: "effectSizeGenEtaSquared";	to: "effectSizeGeneralEtaSquared"	}
 
 		// Model section
 		ChangeRename {	from: "useMultivariateModelFollowup";	to: "multivariateModelFollowup"	}

--- a/inst/Upgrades.qml
+++ b/inst/Upgrades.qml
@@ -23,7 +23,7 @@ Upgrades
 		{
 			name:		"restrictedSE"
 			condition:	function(options) { return options["restrictedSE"] === "none"; }
-			jsValue:	"standard"
+			jsonValue:	"standard"
 		}
 	}
 
@@ -47,7 +47,7 @@ Upgrades
 		{
 			name:		"restrictedSE"
 			condition:	function(options) { return options["restrictedSE"] === "none"; }
-			jsValue:	"standard"
+			jsonValue:	"standard"
 		}
 	}
 
@@ -71,7 +71,7 @@ Upgrades
 		{
 			name:		"restrictedSE"
 			condition:	function(options) { return options["restrictedSE"] === "none"; }
-			jsValue:	"standard"
+			jsonValue:	"standard"
 		}
 	}
 

--- a/inst/Upgrades.qml
+++ b/inst/Upgrades.qml
@@ -453,7 +453,7 @@ Upgrades
 		ChangeRename {	from: "postHocTestsAvailable";					to: "postHocAvailableTerms"					}
 		ChangeRename {	from: "postHocTestsVariables";					to: "postHocTerms"							}
 		ChangeRename {	from: "postHocTestEffectSize";					to: "postHocEffectSize"						}
-		ChangeRename {	from: "postHocTestPooledError";					to: "postHocPooledError"			}
+		ChangeRename {	from: "postHocTestPooledError";					to: "postHocPooledError"					}
 
 		ChangeRename {	from: "postHocTestsHolm";						to: "postHocCorrectionHolm"					}
 		ChangeRename {	from: "postHocTestsBonferroni";					to: "postHocCorrectionBonferroni"			}

--- a/inst/Upgrades.qml
+++ b/inst/Upgrades.qml
@@ -221,4 +221,148 @@ Upgrades
 		ChangeRename {	from: "kruskalVariablesAvailable";	to: "kruskalWallisAvailableFactors"	}
 		ChangeRename {	from: "kruskalVariablesAssigned";	to: "kruskalWallisFactors"			}
 	}
+
+	Upgrade
+	{
+		functionName:		"Ancova"
+		fromVersion:		"0.16.3"
+		toVersion:			"0.16.4"
+
+		// Display.qml
+		ChangeRename {	from: "VovkSellkeMPR";	to: "vovkSellke"	}
+
+		// AssumptionChecks.qml
+		ChangeRename {	from: "factorCovariateIndependence";	to: "factorCovariateIndependenceCheck"	}
+
+		// Contrasts.qml
+		ChangeRename {	from: "confidenceIntervalsContrast";			to: "contrastCi"		}
+		ChangeRename {	from: "confidenceIntervalIntervalContrast";		to: "contrastCiLevel"	}
+
+		// OrderRestrictions.qml
+		ChangeRename {	from: "restrictedIncludeIntercept";					to: "restrictedInterceptInclusion"					}
+		ChangeRename {	from: "restrictedModelShowAvailableCoefficients";	to: "restrictedAvailableCoefficients"				}
+		ChangeRename {	from: "restrictedModelSummaryByDefault";			to: "restrictedModelSummaryForAllModels"			}
+		ChangeRename {	from: "restrictedMarginalMeansByDefault";			to: "restrictedMarginalMeanForAllModels"			}
+		ChangeRename {	from: "restrictedInformedHypothesisTestByDefault";	to: "restrictedInformedHypothesisTestForAllModels"	}
+
+		// restrictedModels is an array of option lists so we need to change the option names for each model
+		ChangeJS
+		{
+			name: "restrictedModels"
+			jsFunction: function(options)
+			{
+				let newModels = options["restrictedModels"].map(model => {
+					let newModel = {};
+					newModel.informedHypothesisTest	= model.informedHypothesisTest;
+					newModel.marginalMean			= model.marginalMeans;
+					newModel.summary				= model.modelSummary;
+					newModel.name					= model.modelName;
+					newModel.syntax					= model.restrictionSyntax;
+
+					return newModel ;
+				});
+
+				return newModels;
+			}
+		}
+
+		ChangeRename {	from: "restrictedModelComparisonHighlightCoefficients";		to: "restrictedModelComparisonCoefficientsHighlight"	}
+
+		ChangeRename {	from: "restrictedSE";	to: "restrictedHeterogeneityCorrection"	}
+
+		ChangeJS
+		{
+			name: "restrictedHeterogeneityCorrection"
+			jsFunction: function(options)
+			{
+				switch(options["restrictedHeterogeneityCorrection"])
+				{
+					case "standard":	return "none";
+					case "HC0":			return "huberWhite0";
+					case "HC1":			return "huberWhite1";
+					case "HC2":			return "huberWhite2";
+					case "HC3":			return "huberWhite3";
+					case "HC4":			return "huberWhite4";
+					case "HC4m":		return "huberWhite4m";
+					case "HC5":			return "huberWhite5";
+					default:			return options["restrictedHeterogeneityCorrection"];
+				}
+			}
+		}
+
+		ChangeRename {	from: "restrictedBootstrapping";								to: "restrictedBootstrap"			}
+		ChangeRename {	from: "restrictedBootstrappingReplicates";						to: "restrictedBootstrapSamples"	}
+		ChangeRename {	from: "restrictedBootstrappingConfidenceIntervalLevel";			to: "restrictedBootstrapCiLevel"	}
+
+		ChangeRename {	from: "restrictedModelMarginalMeansTerms";	to: "restrictedMarginalMeanTerms"	}
+
+		// PostHoc.qml
+		ChangeRename {	from: "postHocTestsAvailable";					to: "postHocAvailableTerms"					}
+		ChangeRename {	from: "postHocTestsVariables";					to: "postHocTerms"							}
+		ChangeRename {	from: "postHocTestsTypeStandard";				to: "postHocTypeStandard"					}
+		ChangeRename {	from: "postHocBootstrapping";					to: "postHocTypeStandardBootstrap"			}
+		ChangeRename {	from: "postHocTestsBootstrappingReplicates";	to: "postHocTypeStandardBootstrapSamples"	}
+		ChangeRename {	from: "postHocTestEffectSize";					to: "postHocTypeStandardEffectSize"			}
+		ChangeRename {	from: "postHocTestsTypeGames";					to: "postHocTypeGames"						}
+		ChangeRename {	from: "postHocTestsTypeDunnett";				to: "postHocTypeDunnet"						}
+		ChangeRename {	from: "postHocTestsTypeDunn";					to: "postHocTypeDunn"						}
+		ChangeRename {	from: "postHocTestsTukey";						to: "postHocCorrectionTukey"				}
+		ChangeRename {	from: "postHocTestsScheffe";					to: "postHocCorrectionScheffe"				}
+		ChangeRename {	from: "postHocTestsBonferroni";					to: "postHocCorrectionBonferroni"			}
+		ChangeRename {	from: "postHocTestsHolm";						to: "postHocCorrectionHolm"					}
+		ChangeRename {	from: "postHocTestsSidak";						to: "postHocCorrectionSidak"				}
+
+		// PostHocDiplay.qml
+		ChangeRename {	from: "confidenceIntervalsPostHoc";			to: "postHocCi"					}
+		ChangeRename {	from: "confidenceIntervalIntervalPostHoc";	to: "postHocCiLevel"			}
+		ChangeRename {	from: "postHocFlagSignificant";				to: "postHocSignificanceFlag"	}
+
+		// DescriptivePlots.qml
+		ChangeRename {	from: "descriptivePlotsVariables";	to: "descriptivePlotAvailableFactors"	}
+		ChangeRename {	from: "plotHorizontalAxis";			to: "descriptivePlotHorizontalAxis"		}
+		ChangeRename {	from: "plotSeparateLines";			to: "descriptivePlotSeparateLines"		}
+		ChangeRename {	from: "plotSeparatePlots";			to: "descriptivePlotSeparatePlot"		}
+		ChangeRename {	from: "plotErrorBars";				to: "descriptivePlotErrorBar"			}
+		ChangeRename {	from: "errorBarType";				to: "descriptivePlotErrorBarType"		}
+
+		ChangeJS
+		{
+			name: "descriptivePlotErrorBarType"
+			jsFunction: function(options)
+			{
+				switch(options["descriptivePlotErrorBarType"])
+				{
+					case "confidenceInterval":	return "ci";
+					case "standardError":		return "se";
+					default:					return options["descriptivePlotErrorBarType"];
+				}
+			}
+		}
+
+		ChangeRename {	from: "confidenceIntervalInterval";		to: "descriptivePlotCiLevel"	}
+
+		// RainCloudPlots.qml
+		ChangeRename {	from: "rainCloudPlotsVariables";			to: "rainCloudAvailableFactors"		}
+		ChangeRename {	from: "rainCloudPlotsHorizontalAxis";		to: "rainCloudHorizontalAxis"		}
+		ChangeRename {	from: "rainCloudPlotsSeparatePlots";		to: "rainCloudSeparatePlots"		}
+
+
+		// MarginalMeans.qml
+		ChangeRename {	from: "marginalMeansTermsAvailable";			to: "marginalMeanAvailableTerms"	}
+		ChangeRename {	from: "marginalMeansTerms";						to: "marginalMeanTerms"				}
+		ChangeRename {	from: "marginalMeansBootstrapping";				to: "marginalMeanBootstrap"			}
+		ChangeRename {	from: "marginalMeansBootstrappingReplicates";	to: "marginalMeanBootstrapSamples"	}
+		ChangeRename {	from: "marginalMeansCompareMainEffects";		to: "marginalMeanComparedToZero"	}
+		ChangeRename {	from: "marginalMeansCIAdjustment";				to: "marginalMeanCiCorrection"		}
+
+		// SimpleMainEffects
+		ChangeRename {	from: "effectsVariables";		to: "simpleMainEffectAvailableFactors"		}
+		ChangeRename {	from: "simpleFactor";			to: "simpleMainEffectFactor"				}
+		ChangeRename {	from: "moderatorFactorOne";		to: "simpleMainEffectModeratorFactorOne"	}
+		ChangeRename {	from: "moderatorFactorTwo";		to: "simpleMainEffectModeratorFactorTwo"	}
+
+		// Nonparametrics
+		ChangeRename {	from: "kruskalVariablesAvailable";	to: "kruskalWallisAvailableFactors"	}
+		ChangeRename {	from: "kruskalVariablesAssigned";	to: "kruskalWallisFactors"			}
+	}
 }

--- a/inst/Upgrades.qml
+++ b/inst/Upgrades.qml
@@ -74,4 +74,151 @@ Upgrades
 			jsValue:	"standard"
 		}
 	}
+
+	// Option renaming for syntax
+	Upgrade
+	{
+		functionName:		"Anova"
+		fromVersion:		"0.16.3"
+		toVersion:			"0.16.4"
+
+		// Display.qml
+		ChangeRename {	from: "VovkSellkeMPR";	to: "vovkSellke"	}
+
+		// AssumptionChecks.qml
+		ChangeRename {	from: "homogeneityNone";	to: "homogeneityCorrectionNone"		}
+		ChangeRename {	from: "homogeneityBrown";	to: "homogeneityCorrectionBrown"	}
+		ChangeRename {	from: "homogeneityWelch";	to: "homogeneityCorrectionWelch"	}
+
+		// Contrasts.qml
+		ChangeRename {	from: "confidenceIntervalsContrast";			to: "contrastCi"		}
+		ChangeRename {	from: "confidenceIntervalIntervalContrast";		to: "contrastCiLevel"	}
+
+		// OrderRestrictions.qml
+		ChangeRename {	from: "restrictedIncludeIntercept";					to: "restrictedInterceptInclusion"					}
+		ChangeRename {	from: "restrictedModelShowAvailableCoefficients";	to: "restrictedAvailableCoefficients"				}
+		ChangeRename {	from: "restrictedModelSummaryByDefault";			to: "restrictedModelSummaryForAllModels"			}
+		ChangeRename {	from: "restrictedMarginalMeansByDefault";			to: "restrictedMarginalMeanForAllModels"			}
+		ChangeRename {	from: "restrictedInformedHypothesisTestByDefault";	to: "restrictedInformedHypothesisTestForAllModels"	}
+
+		// restrictedModels is an array of option lists so we need to change the option names for each model
+		ChangeJS
+		{
+			name: "restrictedModels"
+			jsFunction: function(options)
+			{
+				let newModels = options["restrictedModels"].map(model => {
+					let newModel = {};
+					newModel.informedHypothesisTest	= model.informedHypothesisTest;
+					newModel.marginalMean			= model.marginalMeans;
+					newModel.summary				= model.modelSummary;
+					newModel.name					= model.modelName;
+					newModel.syntax					= model.restrictionSyntax;
+
+					return newModel ;
+				});
+
+				return newModels;
+			}
+		}
+
+		ChangeRename {	from: "restrictedModelComparisonHighlightCoefficients";		to: "restrictedModelComparisonCoefficientsHighlight"	}
+
+		ChangeRename {	from: "restrictedSE";	to: "restrictedHeterogeneityCorrection"	}
+
+		ChangeJS
+		{
+			name: "restrictedHeterogeneityCorrection"
+			jsFunction: function(options)
+			{
+				switch(options["restrictedHeterogeneityCorrection"])
+				{
+					case "standard":	return "none";
+					case "HC0":			return "huberWhite0";
+					case "HC1":			return "huberWhite1";
+					case "HC2":			return "huberWhite2";
+					case "HC3":			return "huberWhite3";
+					case "HC4":			return "huberWhite4";
+					case "HC4m":		return "huberWhite4m";
+					case "HC5":			return "huberWhite5";
+					default:			return options["restrictedHeterogeneityCorrection"];
+				}
+			}
+		}
+
+		ChangeRename {	from: "restrictedBootstrapping";								to: "restrictedBootstrap"			}
+		ChangeRename {	from: "restrictedBootstrappingReplicates";						to: "restrictedBootstrapSamples"	}
+		ChangeRename {	from: "restrictedBootstrappingConfidenceIntervalLevel";			to: "restrictedBootstrapCiLevel"	}
+
+		ChangeRename {	from: "restrictedModelMarginalMeansTerms";	to: "restrictedMarginalMeanTerms"	}
+
+		// PostHoc.qml
+		ChangeRename {	from: "postHocTestsAvailable";					to: "postHocAvailableTerms"					}
+		ChangeRename {	from: "postHocTestsVariables";					to: "postHocTerms"							}
+		ChangeRename {	from: "postHocTestsTypeStandard";				to: "postHocTypeStandard"					}
+		ChangeRename {	from: "postHocBootstrapping";					to: "postHocTypeStandardBootstrap"			}
+		ChangeRename {	from: "postHocTestsBootstrappingReplicates";	to: "postHocTypeStandardBootstrapSamples"	}
+		ChangeRename {	from: "postHocTestEffectSize";					to: "postHocTypeStandardEffectSize"			}
+		ChangeRename {	from: "postHocTestsTypeGames";					to: "postHocTypeGames"						}
+		ChangeRename {	from: "postHocTestsTypeDunnett";				to: "postHocTypeDunnet"						}
+		ChangeRename {	from: "postHocTestsTypeDunn";					to: "postHocTypeDunn"						}
+		ChangeRename {	from: "postHocTestsTukey";						to: "postHocCorrectionTukey"				}
+		ChangeRename {	from: "postHocTestsScheffe";					to: "postHocCorrectionScheffe"				}
+		ChangeRename {	from: "postHocTestsBonferroni";					to: "postHocCorrectionBonferroni"			}
+		ChangeRename {	from: "postHocTestsHolm";						to: "postHocCorrectionHolm"					}
+		ChangeRename {	from: "postHocTestsSidak";						to: "postHocCorrectionSidak"				}
+
+		// PostHocDiplay.qml
+		ChangeRename {	from: "confidenceIntervalsPostHoc";			to: "postHocCi"					}
+		ChangeRename {	from: "confidenceIntervalIntervalPostHoc";	to: "postHocCiLevel"			}
+		ChangeRename {	from: "postHocFlagSignificant";				to: "postHocSignificanceFlag"	}
+
+		// DescriptivePlots.qml
+		ChangeRename {	from: "descriptivePlotsVariables";	to: "descriptivePlotAvailableFactors"	}
+		ChangeRename {	from: "plotHorizontalAxis";			to: "descriptivePlotHorizontalAxis"		}
+		ChangeRename {	from: "plotSeparateLines";			to: "descriptivePlotSeparateLines"		}
+		ChangeRename {	from: "plotSeparatePlots";			to: "descriptivePlotSeparatePlot"		}
+		ChangeRename {	from: "plotErrorBars";				to: "descriptivePlotErrorBar"			}
+		ChangeRename {	from: "errorBarType";				to: "descriptivePlotErrorBarType"		}
+
+		ChangeJS
+		{
+			name: "descriptivePlotErrorBarType"
+			jsFunction: function(options)
+			{
+				switch(options["descriptivePlotErrorBarType"])
+				{
+					case "confidenceInterval":	return "ci";
+					case "standardError":		return "se";
+					default:					return options["descriptivePlotErrorBarType"];
+				}
+			}
+		}
+
+		ChangeRename {	from: "confidenceIntervalInterval";		to: "descriptivePlotCiLevel"	}
+
+		// RainCloudPlots.qml
+		ChangeRename {	from: "rainCloudPlotsVariables";			to: "rainCloudAvailableFactors"		}
+		ChangeRename {	from: "rainCloudPlotsHorizontalAxis";		to: "rainCloudHorizontalAxis"		}
+		ChangeRename {	from: "rainCloudPlotsSeparatePlots";		to: "rainCloudSeparatePlots"		}
+
+
+		// MarginalMeans.qml
+		ChangeRename {	from: "marginalMeansTermsAvailable";			to: "marginalMeanAvailableTerms"	}
+		ChangeRename {	from: "marginalMeansTerms";						to: "marginalMeanTerms"				}
+		ChangeRename {	from: "marginalMeansBootstrapping";				to: "marginalMeanBootstrap"			}
+		ChangeRename {	from: "marginalMeansBootstrappingReplicates";	to: "marginalMeanBootstrapSamples"	}
+		ChangeRename {	from: "marginalMeansCompareMainEffects";		to: "marginalMeanComparedToZero"	}
+		ChangeRename {	from: "marginalMeansCIAdjustment";				to: "marginalMeanCiCorrection"		}
+
+		// SimpleMainEffects
+		ChangeRename {	from: "effectsVariables";		to: "simpleMainEffectAvailableFactors"		}
+		ChangeRename {	from: "simpleFactor";			to: "simpleMainEffectFactor"				}
+		ChangeRename {	from: "moderatorFactorOne";		to: "simpleMainEffectModeratorFactorOne"	}
+		ChangeRename {	from: "moderatorFactorTwo";		to: "simpleMainEffectModeratorFactorTwo"	}
+
+		// Nonparametrics
+		ChangeRename {	from: "kruskalVariablesAvailable";	to: "kruskalWallisAvailableFactors"	}
+		ChangeRename {	from: "kruskalVariablesAssigned";	to: "kruskalWallisFactors"			}
+	}
 }

--- a/inst/qml/Ancova.qml
+++ b/inst/qml/Ancova.qml
@@ -55,7 +55,7 @@ Form
 	Classical.AssumptionChecks
 	{
 		analysis: form.analysis
-		CheckBox { name: "factorCovariateIndependence";	label: qsTr("Factor covariate independence check");	debug: true	}
+		CheckBox { name: "factorCovariateIndependenceCheck";	label: qsTr("Factor covariate independence check");	debug: true	}
 	}
 
 	Classical.Contrasts

--- a/inst/qml/AnovaRepeatedMeasures.qml
+++ b/inst/qml/AnovaRepeatedMeasures.qml
@@ -153,7 +153,7 @@ Form
 	Classical.SimpleMainEffects
 	{
 		source: ["repeatedMeasuresFactors", "betweenSubjectFactors"]
-		CheckBox { name: "poolErrorTermSimpleEffects";	label: qsTr("Pool error terms") }
+		CheckBox { name: "simpleMainEffectErrorTermPooled";	label: qsTr("Pool error terms") }
 	}
 
 	Section

--- a/inst/qml/AnovaRepeatedMeasures.qml
+++ b/inst/qml/AnovaRepeatedMeasures.qml
@@ -163,7 +163,7 @@ Form
 		VariablesForm
 		{
 			preferredHeight: 150 * preferencesModel.uiScale
-			AvailableVariablesList	{ name: "kruskalVariablesAvailable";	title: qsTr("Factors"); source: ["repeatedMeasuresFactors", "betweenSubjectFactors"]	}
+			AvailableVariablesList	{ name: "friedmanAvailableFactors";		title: qsTr("Factors"); source: ["repeatedMeasuresFactors", "betweenSubjectFactors"]	}
 			AssignedVariablesList	{ name: "friedmanWithinFactor";			title: qsTr("RM Factor")																}
 			AssignedVariablesList	{ name: "friedmanBetweenFactor";		title: qsTr("Optional Grouping Factor"); singleVariable: true							}
 		}

--- a/inst/qml/AnovaRepeatedMeasures.qml
+++ b/inst/qml/AnovaRepeatedMeasures.qml
@@ -66,7 +66,7 @@ Form
 
 		Classical.SumOfSquares{}
 
-		CheckBox { name: "useMultivariateModelFollowup";	label: qsTr("Use multivariate model for follow-up tests");	checked: false }
+		CheckBox { name: "multivariateModelFollowup";	label: qsTr("Use multivariate model for follow-up tests");	checked: false }
 	}
 
 	Section
@@ -80,9 +80,9 @@ Form
 			{
 				title: qsTr("Sphericity corrections")
 				columns: 3
-				CheckBox { name: "sphericityNone";				label: qsTr("None");				checked: true }
-				CheckBox { name: "sphericityGreenhouseGeisser";	label: qsTr("Greenhouse-Geisser");	checked: false }
-				CheckBox { name: "sphericityHuynhFeldt";		label: qsTr("Huynh-Feldt");			checked: false }
+				CheckBox { name: "sphericityCorrectionNone";				label: qsTr("None");				checked: true }
+				CheckBox { name: "sphericityCorrectionGreenhouseGeisser";	label: qsTr("Greenhouse-Geisser");	checked: false }
+				CheckBox { name: "sphericityCorrectionHuynhFeldt";			label: qsTr("Huynh-Feldt");			checked: false }
 			}
 			CheckBox { name: "homogeneityTests"; label: qsTr("Homogeneity tests") }
 		}
@@ -108,24 +108,24 @@ Form
 		VariablesForm
 		{
 			preferredHeight: 150 * preferencesModel.uiScale
-			AvailableVariablesList { name: "postHocTestsAvailable"; source: ["withinModelTerms", { name: "betweenModelTerms", discard: "covariates", combineWithOtherModels: true }] }
-			AssignedVariablesList {  name: "postHocTestsVariables" }
+			AvailableVariablesList { name: "postHocAvailableTerms"; source: ["withinModelTerms", { name: "betweenModelTerms", discard: "covariates", combineWithOtherModels: true }] }
+			AssignedVariablesList {  name: "postHocTerms" }
 		}
 
 		Group
 		{
 			columns: 2
-			CheckBox { name: "postHocTestEffectSize";	label: qsTr("Effect size")						}
-			CheckBox { name: "postHocTestPooledError";	label: qsTr("Pool error term for RM factors");			checked: true	}
+			CheckBox { name: "postHocEffectSize";	label: qsTr("Effect size")						}
+			CheckBox { name: "postHocPooledError";	label: qsTr("Pool error term for RM factors");			checked: true	}
 		}
 
 		Group
 		{
 			title: qsTr("Correction")
-			CheckBox { name: "postHocTestsHolm";		label: qsTr("Holm"); 		checked: true	}
-			CheckBox { name: "postHocTestsBonferroni";	label: qsTr("Bonferroni")			}
-			CheckBox { name: "postHocTestsTukey";		label: qsTr("Tukey")				}
-			CheckBox { name: "postHocTestsScheffe";		label: qsTr("Scheffé")				}
+			CheckBox { name: "postHocCorrectionHolm";			label: qsTr("Holm"); 		checked: true	}
+			CheckBox { name: "postHocCorrectionBonferroni";		label: qsTr("Bonferroni")			}
+			CheckBox { name: "postHocCorrectionTukey";			label: qsTr("Tukey")				}
+			CheckBox { name: "postHocCorrectionScheffe";		label: qsTr("Scheffé")				}
 		}
 
 		Classical.PostHocDisplay{}
@@ -134,8 +134,8 @@ Form
 	Classical.DescriptivePlots
 	{
 		source: ["repeatedMeasuresFactors", "betweenSubjectFactors"]
-		TextField	{ name: "labelYAxis";				label: qsTr("Label y-axis"); fieldWidth: 200	}
-		CheckBox	{ name: "usePooledStandErrorCI";	label: qsTr("Average across unused RM factors")	}
+		TextField	{ name: "descriptivePlotYAxisLabel";		label: qsTr("Label y-axis"); fieldWidth: 200	}
+		CheckBox	{ name: "descriptivePlotErrorBarPooled";	label: qsTr("Average across unused RM factors")	}
 	}
 
 	Common.RainCloudPlots

--- a/inst/qml/AnovaRepeatedMeasuresBayesian.qml
+++ b/inst/qml/AnovaRepeatedMeasuresBayesian.qml
@@ -97,7 +97,7 @@ Form
 	Bayesian.DescriptivesPlots
 	{
 		source: ["repeatedMeasuresFactors", "betweenSubjectFactors"]
-		showLabel: true
+		TextField	{ name: "descriptivePlotYAxisLabel";	label: qsTr("Label y-axis"); fieldWidth: 200	}
 	}
 
 	Common.RainCloudPlots

--- a/inst/qml/common/RainCloudPlots.qml
+++ b/inst/qml/common/RainCloudPlots.qml
@@ -47,7 +47,7 @@ Section
 	
 	TextField
 	{
-		name: "rainCloudPlotsLabelYAxis";
+		name: "rainCloudYAxisLabel";
 		label: qsTr("Label y-axis");
 		fieldWidth: 200;
 		visible: enableYAxisLabel

--- a/inst/qml/common/RainCloudPlots.qml
+++ b/inst/qml/common/RainCloudPlots.qml
@@ -33,9 +33,9 @@ Section
 	VariablesForm
 	{
 		preferredHeight: 150 * preferencesModel.uiScale
-		AvailableVariablesList { name: "rainCloudPlotsVariables";		title: qsTr("Factors"); id: availableTerms }
-		AssignedVariablesList { name: "rainCloudPlotsHorizontalAxis";	title: qsTr("Horizontal Axis"); singleVariable: true; suggestedColumns: suggested }
-		AssignedVariablesList { name: "rainCloudPlotsSeparatePlots";	title: qsTr("Separate Plots");	singleVariable: true; suggestedColumns: suggested }
+		AvailableVariablesList	{ name: "rainCloudAvailableFactors";		title: qsTr("Factors"); id: availableTerms }
+		AssignedVariablesList	{ name: "rainCloudHorizontalAxis";	title: qsTr("Horizontal Axis"); singleVariable: true; suggestedColumns: suggested }
+		AssignedVariablesList	{ name: "rainCloudSeparatePlots";	title: qsTr("Separate Plots");	singleVariable: true; suggestedColumns: suggested }
 	}
 
 	CheckBox

--- a/inst/qml/common/RainCloudPlots.qml
+++ b/inst/qml/common/RainCloudPlots.qml
@@ -40,7 +40,7 @@ Section
 
 	CheckBox
 	{
-		name: "rainCloudPlotsHorizontalDisplay";
+		name: "rainCloudHorizontalDisplay";
 		label: qsTr("Horizontal display");
 		visible: enableHorizontal 
 	}

--- a/inst/qml/common/bayesian/DescriptivesPlots.qml
+++ b/inst/qml/common/bayesian/DescriptivesPlots.qml
@@ -23,36 +23,28 @@ import JASP				1.0
 
 Section
 {
-	property bool showLabel: false
 	property alias source: descriptivePlotsVariables.source
-
-	title: qsTr("Descriptives Plots")
+	title:		qsTr("Descriptives Plots")
+	columns:	1
 
 	VariablesForm
 	{
 		preferredHeight: 150 * preferencesModel.uiScale
 
-		AvailableVariablesList { name: "descriptivePlotsVariables" ;	title: qsTr("Factors"); id: descriptivePlotsVariables }
-		AssignedVariablesList { name: "plotHorizontalAxis";				title: qsTr("Horizontal Axis");	singleVariable: true }
-		AssignedVariablesList { name: "plotSeparateLines";				title: qsTr("Separate Lines");	singleVariable: true }
-		AssignedVariablesList { name: "plotSeparatePlots";				title: qsTr("Separate Plots");	singleVariable: true }
-	}
-
-	TextField
-	{
-		visible: showLabel
-		name: "labelYAxis"; label: qsTr("Label y-axis"); fieldWidth: 200
+		AvailableVariablesList	{ name: "descriptivePlotAvailableFactors";	title: qsTr("Factors");		id: descriptivePlotsVariables	}
+		AssignedVariablesList	{ name: "descriptivePlotHorizontalAxis";	title: qsTr("Horizontal Axis");	singleVariable: true		}
+		AssignedVariablesList	{ name: "descriptivePlotSeparateLines";		title: qsTr("Separate Lines");	singleVariable: true		}
+		AssignedVariablesList	{ name: "descriptivePlotSeparatePlot";		title: qsTr("Separate Plots");	singleVariable: true		}
 	}
 
 	Group
 	{
-
 		title: qsTr("Display")
 		CheckBox
 		{
-			name: "plotCredibleInterval"; label: qsTr("Credible interval")
+			name: "descriptivePlotCi"; label: qsTr("Credible interval")
 			childrenOnSameRow: true
-			CIField { name: "plotCredibleIntervalInterval" }
+			CIField { name: "descriptivePlotCiLevel" }
 		}
 	}
 }

--- a/inst/qml/common/classical/AssumptionChecks.qml
+++ b/inst/qml/common/classical/AssumptionChecks.qml
@@ -39,9 +39,9 @@ Section
 			{
 				title: qsTr("Homogeneity corrections")
 				columns: 3
-				CheckBox { name: "homogeneityNone";		label: qsTr("None")           ; checked: true }
-				CheckBox { name: "homogeneityBrown";	label: qsTr("Brown-Forsythe") ; checked: false }
-				CheckBox { name: "homogeneityWelch";	label: qsTr("Welch")          ; checked: false }
+				CheckBox { name: "homogeneityCorrectionNone";		label: qsTr("None")           ; checked: true }
+				CheckBox { name: "homogeneityCorrectionBrown";		label: qsTr("Brown-Forsythe") ; checked: false }
+				CheckBox { name: "homogeneityCorrectionWelch";		label: qsTr("Welch")          ; checked: false }
 			}
 		}
 		sourceComponent: analysis === Common.Type.Analysis.ANOVA ? homogeneityCorrections : undefined

--- a/inst/qml/common/classical/Contrasts.qml
+++ b/inst/qml/common/classical/Contrasts.qml
@@ -35,15 +35,15 @@ Section
 		Component
 		{
 			id: equalVarianceAssumption
-			CheckBox { name: "contrastAssumeEqualVariance"; label: qsTr("Assume equal variances"); checked: true }
+			CheckBox { name: "contrastEqualVariance"; label: qsTr("Assume equal variances"); checked: true }
 		}
 		sourceComponent: analysis === Common.Type.Analysis.RMANOVA ? equalVarianceAssumption : undefined
 	}
 
 	CheckBox
 	{
-		name: "confidenceIntervalsContrast"; label: qsTr("Confidence intervals")
+		name: "contrastCi"; label: qsTr("Confidence intervals")
 		childrenOnSameRow: true
-		CIField {	name: "confidenceIntervalIntervalContrast" }
+		CIField {	name: "contrastCiLevel" }
 	}
 }

--- a/inst/qml/common/classical/DescriptivePlots.qml
+++ b/inst/qml/common/classical/DescriptivePlots.qml
@@ -30,10 +30,10 @@ Section
 	VariablesForm
 	{
 		preferredHeight: 150 * preferencesModel.uiScale
-		AvailableVariablesList	{ name: "descriptivePlotsVariables";	title: qsTr("Factors");	id: availableTerms }
-		AssignedVariablesList	{ name: "plotHorizontalAxis";			title: qsTr("Horizontal Axis");	singleVariable: true }
-		AssignedVariablesList	{ name: "plotSeparateLines";			title: qsTr("Separate Lines");	singleVariable: true }
-		AssignedVariablesList	{ name: "plotSeparatePlots";			title: qsTr("Separate Plots");	singleVariable: true }
+		AvailableVariablesList	{ name: "descriptivePlotAvailableFactors";	title: qsTr("Factors");	id: availableTerms }
+		AssignedVariablesList	{ name: "descriptivePlotHorizontalAxis";			title: qsTr("Horizontal Axis");	singleVariable: true }
+		AssignedVariablesList	{ name: "descriptivePlotSeparateLines";			title: qsTr("Separate Lines");	singleVariable: true }
+		AssignedVariablesList	{ name: "descriptivePlotSeparatePlot";			title: qsTr("Separate Plots");	singleVariable: true }
 	}
 
 	Group
@@ -41,17 +41,19 @@ Section
 		title: qsTr("Display")
 		CheckBox
 		{
-			name: "plotErrorBars"; label: qsTr("Display error bars")
+			name: "descriptivePlotErrorBar"; label: qsTr("Display error bars")
 			RadioButtonGroup
 			{
-				name: "errorBarType"
+				name: "descriptivePlotErrorBarType"
 				RadioButton
 				{
-					value: "confidenceInterval";		label: qsTr("Confidence interval"); checked: true
-					childrenOnSameRow: true
-					CIField { name: "confidenceIntervalInterval" }
+					value:				"ci";
+					label:				qsTr("Confidence interval");
+					checked:			true
+					childrenOnSameRow:	true
+					CIField { name: "descriptivePlotCiLevel" }
 				}
-				RadioButton { value: "standardError";	label: qsTr("Standard error") }
+				RadioButton { value: "se";	label: qsTr("Standard error") }
 			}
 		}
 	}

--- a/inst/qml/common/classical/Display.qml
+++ b/inst/qml/common/classical/Display.qml
@@ -46,5 +46,5 @@ Group
 
 		CheckBox { name: "effectSizeOmegaSquared";		label: qsTr("ω²")				}
 	}
-	CheckBox { name: "VovkSellkeMPR"; label: qsTr("Vovk-Sellke maximum p-ratio") }
+	CheckBox { name: "vovkSellke"; label: qsTr("Vovk-Sellke maximum p-ratio") }
 }

--- a/inst/qml/common/classical/Display.qml
+++ b/inst/qml/common/classical/Display.qml
@@ -37,10 +37,10 @@ Group
 		{
 			Component
 			{
-				id: effectSizeGenEtaSquared
-				CheckBox { name: "effectSizeGenEtaSquared";	label: qsTr("general η²")	}
+				id: effectSizeGeneralEtaSquared
+				CheckBox { name: "effectSizeGeneralEtaSquared";	label: qsTr("general η²")	}
 			}
-			sourceComponent: effectSizeGenEtaSquared
+			sourceComponent: effectSizeGeneralEtaSquared
 			active: analysis === Common.Type.Analysis.RMANOVA
 		}
 

--- a/inst/qml/common/classical/MarginalMeans.qml
+++ b/inst/qml/common/classical/MarginalMeans.qml
@@ -30,18 +30,18 @@ Section
 	VariablesForm
 	{
 		preferredHeight:	jaspTheme.smallDefaultVariablesFormHeight
-		AvailableVariablesList { name: "marginalMeansTermsAvailable"; id: availableTerms	}
-		AssignedVariablesList {  name: "marginalMeansTerms"									}
+		AvailableVariablesList { name: "marginalMeanAvailableTerms"; id: availableTerms	}
+		AssignedVariablesList {  name: "marginalMeanTerms"									}
 	}
 
 	CheckBox
 	{
-		name:				"marginalMeansBootstrapping";
+		name:				"marginalMeanBootstrap";
 		label:				qsTr("From")
 		childrenOnSameRow:	true
 		IntegerField
 		{
-			name:			"marginalMeansBootstrappingReplicates"
+			name:			"marginalMeanBootstrapSamples"
 			defaultValue:	1000
 			fieldWidth:		50
 			min:			100
@@ -51,11 +51,11 @@ Section
 
 	CheckBox
 	{
-		name:	"marginalMeansCompareMainEffects";
+		name:	"marginalMeanComparedToZero";
 		label:	qsTr("Compare marginal means to 0")
 		DropDown
 		{
-			name:	"marginalMeansCIAdjustment"
+			name:	"marginalMeanCiCorrection"
 			label:	qsTr("Confidence interval adjustment")
 			values:	[
 				{ label:	qsTr("None"),	value:	"none"},

--- a/inst/qml/common/classical/Nonparametrics.qml
+++ b/inst/qml/common/classical/Nonparametrics.qml
@@ -29,7 +29,7 @@ Section
 	VariablesForm
 	{
 		preferredHeight:	170 * preferencesModel.uiScale
-		AvailableVariablesList	{ name: "kruskalVariablesAvailable";	title: qsTr("Kruskal-Wallis Test");	id: availableTerms	}
-		AssignedVariablesList	{ name: "kruskalVariablesAssigned";		title: qsTr(" ")										}
+		AvailableVariablesList	{ name: "kruskalWallisAvailableFactors";	title: qsTr("Kruskal-Wallis Test");	id: availableTerms	}
+		AssignedVariablesList	{ name: "kruskalWallisFactors";				title: qsTr(" ")										}
 	}
 }

--- a/inst/qml/common/classical/OrderRestrictions.qml
+++ b/inst/qml/common/classical/OrderRestrictions.qml
@@ -54,13 +54,13 @@ Section
 			title:	qsTr("Syntax settings")
 			CheckBox
 			{
-				name:	"restrictedIncludeIntercept"
+				name:	"restrictedInterceptInclusion"
 				label:	qsTr("Include intercept")
 			}
 
 			CheckBox
 			{
-				name:	"restrictedModelShowAvailableCoefficients"
+				name:	"restrictedAvailableCoefficients"
 				label:	qsTr("Show available coefficients")
 			}
 		}
@@ -70,21 +70,21 @@ Section
 			title:		qsTr("Set for all models")
 			CheckBox
 			{
-				name:	"restrictedModelSummaryByDefault"
+				name:	"restrictedModelSummaryForAllModels"
 				id:		modelSummaryByDefault
 				label:	qsTr("Model summary")
 			}
 
 			CheckBox
 			{
-				name:	"restrictedMarginalMeansByDefault"
+				name:	"restrictedMarginalMeanForAllModels"
 				id:		marginalMeansByDefault
 				label:	qsTr("Marginal means")
 			}
 
 			CheckBox
 			{
-				name:		"restrictedInformedHypothesisTestByDefault"
+				name:		"restrictedInformedHypothesisTestForAllModels"
 				id:			informedHypothesisTestByDefault
 				label:		qsTr("Informed hypothesis tests")
 				visible:	analysis !== Common.Type.Analysis.RMANOVA
@@ -98,14 +98,14 @@ Section
 		name:				"restrictedModels"
 		maximumItems:		10
 		newItemName:		qsTr("Model 1")
-		optionKey:			"modelName"
+		optionKey:			"name"
 		Layout.columnSpan:	2
 
 		content: Group
 		{
 			TextArea
 			{
-				name:				"restrictionSyntax"
+				name:				"syntax"
 				width:				models.width
 				textType:			JASP.TextTypeModel
 				trim:				true
@@ -117,14 +117,14 @@ Section
 				columns: 3
 				CheckBox
 				{
-					name:		"modelSummary"
+					name:		"summary"
 					label:		qsTr("Summary for %1").arg(rowValue)
 					checked:	modelSummaryByDefault.checked
 				}
 
 				CheckBox
 				{
-					name:		"marginalMeans"
+					name:		"marginalMean"
 					label:		qsTr("Marginal means for %1").arg(rowValue)
 					checked:	marginalMeansByDefault.checked
 				}
@@ -156,7 +156,7 @@ Section
 			property var comparisonValuesExclComplement: 
 			[
 				{ label: qsTr("Unconstrained model"),	value: "unconstrained"	},
-				{ label: qsTr("None"),					value:"none"			}
+				{ label: qsTr("None"),					value: "none"			}
 			]
 			property var comparisonValues: (models.count > 1) ? comparisonValuesExclComplement : comparisonValuesInclComplement
 			
@@ -199,7 +199,7 @@ Section
 			
 			CheckBox
 			{
-				name:		"restrictedModelComparisonHighlightCoefficients"
+				name:		"restrictedModelComparisonCoefficientsHighlight"
 				label:		qsTr("Highlight active restrictions")
 				checked:	true
 			}
@@ -212,32 +212,32 @@ Section
 
 		DropDown
 		{
-			name:				"restrictedSE"
+			name:				"restrictedHeterogeneityCorrection"
 			label:				qsTr("Heterogeneity correction")
 			visible:			analysis !== Common.Type.Analysis.RMANOVA
 			indexDefaultValue:	0
 			values:
 			[
-				{ label: qsTr("None"),	value: "standard"	},
-				{ label: qsTr("HC0"),	value: "HC0"		},
-				{ label: qsTr("HC1"),	value: "HC1"		},
-				{ label: qsTr("HC2"),	value: "HC2"		},
-				{ label: qsTr("HC3"),	value: "HC3"		},
-				{ label: qsTr("HC4"),	value: "HC4"		},
-				{ label: qsTr("HC4m"),	value: "HC4m"		},
-				{ label: qsTr("HC5"),	value: "HC5"		}
+				{ label: qsTr("None"),	value: "none"			},
+				{ label: qsTr("HC0"),	value: "huberWhite0"	},
+				{ label: qsTr("HC1"),	value: "huberWhite1"	},
+				{ label: qsTr("HC2"),	value: "huberWhite2"	},
+				{ label: qsTr("HC3"),	value: "huberWhite3"	},
+				{ label: qsTr("HC4"),	value: "huberWhite4"	},
+				{ label: qsTr("HC4m"),	value: "huberWhite4m"	},
+				{ label: qsTr("HC5"),	value: "huberWhite5"	}
 			]
 		}
 
 
 		CheckBox
 		{
-			name:	"restrictedBootstrapping"
+			name:	"restrictedBootstrap"
 			label:	qsTr("Bootstrapping")
 
 			IntegerField
 			{
-				name:			"restrictedBootstrappingReplicates"
+				name:			"restrictedBootstrapSamples"
 				defaultValue:	1000
 				fieldWidth:		50
 				min:			100
@@ -246,7 +246,7 @@ Section
 
 			CIField
 			{
-				name:	"restrictedBootstrappingConfidenceIntervalLevel"
+				name:	"restrictedBootstrapCiLevel"
 				label:	qsTr("Confidence intervals")
 			}
 		}
@@ -264,7 +264,7 @@ Section
 			id: marginalMeansTerms
 		}
 
-		AssignedVariablesList { name: "restrictedModelMarginalMeansTerms"; label: qsTr("Terms") }
+		AssignedVariablesList { name: "restrictedMarginalMeanTerms"; label: qsTr("Terms") }
 	}
 
 

--- a/inst/qml/common/classical/PostHoc.qml
+++ b/inst/qml/common/classical/PostHoc.qml
@@ -31,8 +31,8 @@ Section
 	VariablesForm
 	{
 		preferredHeight: jaspTheme.smallDefaultVariablesFormHeight
-		AvailableVariablesList { name: "postHocTestsAvailable"; id: availableTerms }
-		AssignedVariablesList {  name: "postHocTestsVariables" }
+		AvailableVariablesList	{	name: "postHocAvailableTerms";	id: availableTerms }
+		AssignedVariablesList	{	name: "postHocTerms" }
 	}
 
 
@@ -41,16 +41,16 @@ Section
 		title: qsTr("Type")
 		CheckBox
 		{
-			name: "postHocTestsTypeStandard";	label: qsTr("Standard"); checked: true
+			name: "postHocTypeStandard";	label: qsTr("Standard"); checked: true
 			Group
 			{
 				CheckBox
 				{
-					name: "postHocTestsBootstrapping"; label: qsTr("From")
+					name: "postHocTypeStandardBootstrap"; label: qsTr("From")
 					childrenOnSameRow: true
 					IntegerField
 					{
-						name: "postHocTestsBootstrappingReplicates"
+						name: "postHocTypeStandardBootstrapSamples"
 						defaultValue: 1000
 						fieldWidth: 50
 						min: 100
@@ -58,22 +58,22 @@ Section
 					}
 				}
 			}
-			CheckBox { name: "postHocTestEffectSize";	label: qsTr("Effect size") }
+			CheckBox { name: "postHocTypeStandardEffectSize";	label: qsTr("Effect size") }
 		}
-		CheckBox { name: "postHocTestsTypeGames";		label: qsTr("Games-Howell")				}
-		CheckBox { name: "postHocTestsTypeDunnett";		label: qsTr("Dunnett")					}
-		CheckBox { name: "postHocTestsTypeDunn";		label: qsTr("Dunn")						}
+		CheckBox { name: "postHocTypeGames";		label: qsTr("Games-Howell")				}
+		CheckBox { name: "postHocTypeDunnet";		label: qsTr("Dunnett")					}
+		CheckBox { name: "postHocTypeDunn";			label: qsTr("Dunn")						}
 	}
 
 
 	Group
 	{
 		title: qsTr("Correction")
-		CheckBox { name: "postHocTestsTukey";		label: qsTr("Tukey"); checked: true	}
-		CheckBox { name: "postHocTestsScheffe";		label: qsTr("Scheffé")				}
-		CheckBox { name: "postHocTestsBonferroni";	label: qsTr("Bonferroni")			}
-		CheckBox { name: "postHocTestsHolm";		label: qsTr("Holm")					}
-		CheckBox { name: "postHocTestsSidak";       label: qsTr("Šidák")                }
+		CheckBox { name: "postHocCorrectionTukey";			label: qsTr("Tukey"); checked: true	}
+		CheckBox { name: "postHocCorrectionScheffe";		label: qsTr("Scheffé")				}
+		CheckBox { name: "postHocCorrectionBonferroni";		label: qsTr("Bonferroni")			}
+		CheckBox { name: "postHocCorrectionHolm";			label: qsTr("Holm")					}
+		CheckBox { name: "postHocCorrectionSidak";			label: qsTr("Šidák")				}
 	}
 
 	Classical.PostHocDisplay{}

--- a/inst/qml/common/classical/PostHocDisplay.qml
+++ b/inst/qml/common/classical/PostHocDisplay.qml
@@ -26,10 +26,10 @@ Group
 	title: qsTr("Display")
 	CheckBox
 	{
-		name:				"confidenceIntervalsPostHoc";
+		name:				"postHocCi";
 		label:				qsTr("Confidence intervals")
 		childrenOnSameRow:	true
-		CIField { name: "confidenceIntervalIntervalPostHoc" }
+		CIField { name: "postHocCiLevel" }
 	}
-	CheckBox { name: "postHocFlagSignificant";	label: qsTr("Flag Significant Comparisons") }
+	CheckBox { name: "postHocSignificanceFlag";	label: qsTr("Flag Significant Comparisons") }
 }

--- a/inst/qml/common/classical/SimpleMainEffects.qml
+++ b/inst/qml/common/classical/SimpleMainEffects.qml
@@ -29,9 +29,9 @@ Section
 	VariablesForm
 	{
 		preferredHeight:	170 * preferencesModel.uiScale
-		AvailableVariablesList	{ name: "effectsVariables";		title: qsTr("Factors")				; id: availableTerms }
-		AssignedVariablesList	{ name: "simpleFactor";			title: qsTr("Simple Effect Factor") ; singleVariable: true }
-		AssignedVariablesList	{ name: "moderatorFactorOne";	title: qsTr("Moderator Factor 1")	; singleVariable: true }
-		AssignedVariablesList	{ name: "moderatorFactorTwo";	title: qsTr("Moderator Factor 2")	; singleVariable: true }
+		AvailableVariablesList	{ name: "simpleMainEffectAvailableFactors";		title: qsTr("Factors")				; id: availableTerms }
+		AssignedVariablesList	{ name: "simpleMainEffectFactor";				title: qsTr("Simple Effect Factor") ; singleVariable: true }
+		AssignedVariablesList	{ name: "simpleMainEffectModeratorFactorOne";	title: qsTr("Moderator Factor 1")	; singleVariable: true }
+		AssignedVariablesList	{ name: "simpleMainEffectModeratorFactorTwo";	title: qsTr("Moderator Factor 2")	; singleVariable: true }
 	}
 }

--- a/tests/testthat/test-ancova.R
+++ b/tests/testthat/test-ancova.R
@@ -19,7 +19,7 @@ test_that("Main table results match", {
   options$effectSizeEtaSquared <- TRUE
   options$effectSizeOmegaSquared <- TRUE
   options$effectSizePartialEtaSquared <- TRUE
-  options$VovkSellkeMPR <- TRUE
+  options$vovkSellke <- TRUE
 
   refTables <- list(
     type1 = list("facFive", 181.151987151139, 4, 45.2879967877848, 1.86433860843651,
@@ -110,7 +110,7 @@ test_that("Homogeneity of Variances table results match", {
     list(components="contGamma")
   )
   options$homogeneityTests <- TRUE
-  options$VovkSellkeMPR <- TRUE
+  options$vovkSellke <- TRUE
   results <- jaspTools::runAnalysis("Ancova", "test.csv", options)
   table <- results[["results"]][["anovaContainer"]][["collection"]][["anovaContainer_assumptionsContainer"]][["collection"]][["anovaContainer_assumptionsContainer_leveneTable"]][["data"]]
   jaspTools::expect_equal_tables(table, list(2.72159218177061, 1, 98, 0.102201011380302, 1.57819444559362))
@@ -127,7 +127,7 @@ test_that("Contrasts table results match", {
     list(components="facFive"),
     list(components="contGamma")
   )
-  options$confidenceIntervalsContrast <- TRUE
+  options$contrastCi <- TRUE
   refTables <- list(
     deviation = list("2 - 1, 2, 3, 4, 5", -0.200720248979633, 0.213572066533121, -0.939824445386938,
                      0.349716429527485, 94, -0.6247726, 0.2233321, "TRUE", "3 - 1, 2, 3, 4, 5", 0.326355030521638,
@@ -187,15 +187,15 @@ test_that("Post Hoc table results match", {
     list(components="facExperim"),
     list(components="contGamma")
   )
-  options$postHocTestEffectSize <- TRUE
-  options$postHocTestsBonferroni <- TRUE
-  options$postHocTestsHolm <- TRUE
-  options$postHocTestsScheffe <- TRUE
-  options$postHocTestsTukey <- TRUE
-  options$postHocTestsSidak <- TRUE
-  options$postHocTestsVariables <- list("facExperim")
-  options$postHocTestsTypeStandard <- TRUE
-  options$confidenceIntervalsPostHoc <- TRUE
+  options$postHocTerms                  <- list("facExperim")
+  options$postHocTypeStandard           <- TRUE
+  options$postHocTypeStandardEffectSize <- TRUE
+  options$postHocCorrectionBonferroni   <- TRUE
+  options$postHocCorrectionHolm         <- TRUE
+  options$postHocCorrectionScheffe      <- TRUE
+  options$postHocCorrectionTukey        <- TRUE
+  options$postHocCorrectionSidak        <- TRUE
+  options$postHocCi                     <- TRUE
   results <- jaspTools::runAnalysis("Ancova", "test.csv", options)
   table <- results$results$anovaContainer$collection$anovaContainer_postHocContainer$collection$anovaContainer_postHocContainer_postHocStandardContainer$collection[[1]]$data
   jaspTools::expect_equal_tables(table,
@@ -216,8 +216,8 @@ test_that("Marginal Means table results match", {
     list(components="facExperim"),
     list(components="contGamma")
   )
-  options$marginalMeansCompareMainEffects <- TRUE
-  options$marginalMeansTerms <- "facExperim"
+  options$marginalMeanComparedToZero <- TRUE
+  options$marginalMeanTerms <- "facExperim"
 
   refTables <- list(
     none = list("control", -0.230293705415766, 0.151049119466849, -0.530084395048618, 97,
@@ -235,7 +235,7 @@ test_that("Marginal Means table results match", {
   )
 
   for (adjustment in c("none", "Bonferroni", "Sidak")) {
-    options$marginalMeansCIAdjustment <- adjustment
+    options$marginalMeanCiCorrection <- adjustment
     results <- jaspTools::runAnalysis("Ancova", "test.csv", options)
     table <- results[["results"]]$anovaContainer$collection$anovaContainer_marginalMeansContainer$collection[[1]]$data
     jaspTools::expect_equal_tables(table, refTables[[adjustment]], label=paste("Table with CI adjustment", adjustment))
@@ -252,12 +252,12 @@ test_that("Simple Main Effects table results match", {
     list(components="facFive"),
     list(components="contGamma")
   )
-  options$simpleFactor <- "facExperim"
-  options$moderatorFactorOne <- "facFive"
-  options$moderatorFactorTwo <- ""
+  options$simpleMainEffectFactor             <- "facExperim"
+  options$simpleMainEffectModeratorFactorOne <- "facFive"
+  options$simpleMainEffectModeratorFactorTwo <- ""
   options$homogeneityTests <- TRUE
   options$sumOfSquares <- "type1"
-  options$VovkSellkeMPR <- TRUE
+  options$vovkSellke <- TRUE
   results <- jaspTools::runAnalysis("Ancova", "debug.csv", options)
   # table <- results[["results"]][["simpleEffects"]][["data"]]
   table <- results$results$anovaContainer$collection$anovaContainer_simpleEffectsContainer$collection$anovaContainer_simpleEffectsContainer_simpleEffectsTable$data
@@ -302,23 +302,23 @@ test_that("Field - Chapter 6 results match", {
     list(components = "Puppy_love")
   )
 
-  options$marginalMeansTerms <- list(
+  options$marginalMeanTerms <- list(
     list(components = "Dose")
   )
-  options$marginalMeansBootstrapping <- TRUE
-  options$marginalMeansBootstrappingReplicates <- 500
+  options$marginalMeanBootstrap <- TRUE
+  options$marginalMeanBootstrapSamples <- 500
 
   options$contrasts <- list(
     list(contrast = "simple", variable = "Dose")
   )
-  options$confidenceIntervalsContrast <- TRUE
+  options$contrastCi <- TRUE
 
-  options$postHocTestsVariables <- "Dose"
-  options$postHocTestsSidak <- TRUE
-  options$postHocTestsTukey <- FALSE
-  options$confidenceIntervalsPostHoc <- TRUE
-  options$postHocTestsBootstrapping <- TRUE
-  options$postHocTestsBootstrappingReplicates <- 500
+  options$postHocTerms <- "Dose"
+  options$postHocCorrectionSidak <- TRUE
+  options$postHocCorrectionTukey <- FALSE
+  options$postHocTypeStandardBootstrap <- TRUE
+  options$postHocTypeStandardBootstrapSamples <- 500
+  options$postHocCi <- TRUE
 
   set.seed(1) # seed for bootstrapping
   results <- jaspTools::runAnalysis("Ancova", "Puppy Love.csv", options)
@@ -376,9 +376,9 @@ test_that("Field - Chapter 6 results match", {
   options$contrasts <- list(
     list(contrast = "none", variable = "Dose")
   )
-  options$plotHorizontalAxis <- "Puppy_love"
-  options$plotSeparatePlots <- "Dose"
-  options$plotErrorBars <- TRUE
+  options$descriptivePlotHorizontalAxis <- "Puppy_love"
+  options$descriptivePlotSeparatePlot <- "Dose"
+  options$descriptivePlotErrorBar <- TRUE
   results <- jaspTools::runAnalysis("Ancova", "Puppy Love.csv", options)
 
   table <- results$result$anovaContainer$collection$anovaContainer_anovaTable$data
@@ -410,34 +410,34 @@ options$customContrasts <- list()
 options$dependent <- "contNormal"
 options$fixedFactors <- "contBinom"
 options$modelTerms <- list(list(components = "contBinom"), list(components = "contcor1"))
-options$rainCloudPlotsHorizontalAxis <- ""
-options$rainCloudPlotsHorizontalDisplay <- FALSE
-options$rainCloudPlotsLabelYAxis <- ""
-options$rainCloudPlotsSeparatePlots <- ""
-options$restrictedBootstrapping <- TRUE
-options$restrictedBootstrappingConfidenceIntervalLevel <- 0.95
-options$restrictedBootstrappingReplicates <- 100
-options$restrictedIncludeIntercept <- TRUE
-options$restrictedInformedHypothesisTestByDefault <- TRUE
-options$restrictedMarginalMeansByDefault <- TRUE
+options$rainCloudHorizontalAxis <- ""
+options$rainCloudHorizontalDisplay <- FALSE
+options$rainCloudYAxisLabel <- ""
+options$rainCloudSeparatePlots <- ""
+options$restrictedBootstrap <- TRUE
+options$restrictedBootstrapCiLevel <- 0.95
+options$restrictedBootstrapSamples <- 100
+options$restrictedInterceptInclusion <- TRUE
+options$restrictedAvailableCoefficients <- TRUE
+options$restrictedInformedHypothesisTestForAllModels <- TRUE
+options$restrictedMarginalMeanForAllModels <- TRUE
+options$restrictedModelSummaryForAllModels <- TRUE
 options$restrictedModelComparison <- "unconstrained"
 options$restrictedModelComparisonCoefficients <- TRUE
-options$restrictedModelComparisonHighlightCoefficients <- TRUE
+options$restrictedModelComparisonCoefficientsHighlight <- TRUE
 options$restrictedModelComparisonMatrix <- TRUE
 options$restrictedModelComparisonReference <- "Model 2"
 options$restrictedModelComparisonWeights <- TRUE
-options$restrictedModelMarginalMeansTerms <- list(list(variable = "contBinom"))
-options$restrictedModelShowAvailableCoefficients <- TRUE
-options$restrictedModelSummaryByDefault <- TRUE
-options$restrictedModels <- list(list(informedHypothesisTest = TRUE, marginalMeans = TRUE,
-                                      modelName = "Model 1", modelSummary = TRUE, restrictionSyntax = ".Intercept. == 0"),
-                                 list(informedHypothesisTest = TRUE, marginalMeans = TRUE,
-                                      modelName = "Model 2", modelSummary = TRUE, restrictionSyntax = ".Intercept. > 0"),
-                                 list(informedHypothesisTest = TRUE, marginalMeans = TRUE,
-                                      modelName = "Model 3", modelSummary = TRUE, restrictionSyntax = ".Intercept. == 0\ncontBinom1 > 0"))
-options$restrictedSE <- "standard"
+options$restrictedMarginalMeanTerms <- list(list(variable = "contBinom"))
+options$restrictedModels <- list(list(informedHypothesisTest = TRUE, marginalMean = TRUE,
+                                      name = "Model 1", summary = TRUE, syntax = ".Intercept. == 0"),
+                                 list(informedHypothesisTest = TRUE, marginalMean = TRUE,
+                                      name = "Model 2", summary = TRUE, syntax = ".Intercept. > 0"),
+                                 list(informedHypothesisTest = TRUE, marginalMean = TRUE,
+                                      name = "Model 3", summary = TRUE, syntax = ".Intercept. == 0\ncontBinom1 > 0"))
+options$restrictedHeterogeneityCorrection <- "none"
 set.seed(1)
-results <- runAnalysis("Ancova", "test.csv", options)
+results <- jaspTools::runAnalysis("Ancova", "test.csv", options)
 
 
 ## Models with equality restrictions only ----
@@ -582,30 +582,30 @@ options$customContrasts <- list()
 options$dependent <- "Anger"
 options$fixedFactors <- "Group"
 options$modelTerms <- list(list(components = "Group"), list(components = "Age"))
-options$rainCloudPlotsHorizontalAxis <- ""
-options$rainCloudPlotsHorizontalDisplay <- FALSE
-options$rainCloudPlotsLabelYAxis <- ""
-options$rainCloudPlotsSeparatePlots <- ""
-options$restrictedBootstrapping <- FALSE
-options$restrictedBootstrappingConfidenceIntervalLevel <- 0.95
-options$restrictedBootstrappingReplicates <- 1000
-options$restrictedIncludeIntercept <- FALSE
-options$restrictedInformedHypothesisTestByDefault <- FALSE
-options$restrictedMarginalMeansByDefault <- FALSE
+options$rainCloudHorizontalAxis <- ""
+options$rainCloudHorizontalDisplay <- FALSE
+options$rainCloudYAxisLabel <- ""
+options$rainCloudSeparatePlots <- ""
+options$restrictedBootstrap <- FALSE
+options$restrictedBootstrapCiLevel <- 0.95
+options$restrictedBootstrapSamples <- 1000
+options$restrictedInterceptInclusion <- FALSE
+options$restrictedAvailableCoefficients <- FALSE
+options$restrictedInformedHypothesisTestForAllModels <- FALSE
+options$restrictedMarginalMeanForAllModels <- FALSE
+options$restrictedModelSummaryForAllModels <- FALSE
 options$restrictedModelComparison <- "none"
 options$restrictedModelComparisonCoefficients <- FALSE
-options$restrictedModelComparisonHighlightCoefficients <- TRUE
+options$restrictedModelComparisonCoefficientsHighlight <- TRUE
 options$restrictedModelComparisonMatrix <- FALSE
 options$restrictedModelComparisonReference <- "Model 1"
 options$restrictedModelComparisonWeights <- FALSE
-options$restrictedModelMarginalMeansTerms <- list(list(variable = "Group"))
-options$restrictedModelShowAvailableCoefficients <- FALSE
-options$restrictedModelSummaryByDefault <- FALSE
-options$restrictedModels <- list(list(informedHypothesisTest = FALSE, marginalMeans = TRUE,
-                                      modelName = "Model 1", modelSummary = FALSE, restrictionSyntax = "GroupNo < GroupPhysical\nGroupPhysical  == GroupBehavioral\nGroupBehavioral < GroupBoth"))
-options$restrictedSE <- "standard"
+options$restrictedMarginalMeanTerms <- list(list(variable = "Group"))
+options$restrictedModels <- list(list(informedHypothesisTest = FALSE, marginalMean = TRUE,
+                                      name = "Model 1", summary = FALSE, syntax = "GroupNo < GroupPhysical\nGroupPhysical  == GroupBehavioral\nGroupBehavioral < GroupBoth"))
+options$restrictedHeterogeneityCorrection <- "none"
 set.seed(1)
-results <- runAnalysis("Ancova", "AngerManagement.csv", options)
+results <- jaspTools::runAnalysis("Ancova", "AngerManagement.csv", options)
 
 test_that("Ordinal restrictions: Adjuested marginal means results match", {
   table <- results[["results"]][["anovaContainer"]][["collection"]][["anovaContainer_ordinalRestrictions"]][["collection"]][["anovaContainer_ordinalRestrictions_Model 1"]][["collection"]][["anovaContainer_ordinalRestrictions_Model 1_marginalMeansContainer"]][["collection"]][["anovaContainer_ordinalRestrictions_Model 1_marginalMeansContainer_Group"]][["data"]]

--- a/tests/testthat/test-ancovabayesian.R
+++ b/tests/testthat/test-ancovabayesian.R
@@ -134,9 +134,9 @@ options$covariates <- "contcor1"
 options$dependent <- "contNormal"
 options$fixedFactors <- "facGender"
 options$modelTerms <- list(list(components = "facGender", isNuisance = FALSE), list(components = "contcor1", isNuisance = FALSE))
-options$plotCredibleInterval <- TRUE
-options$plotHorizontalAxis <- "contcor1"
-options$plotSeparateLines <- "facGender"
+options$descriptivePlotCi <- TRUE
+options$descriptivePlotHorizontalAxis <- "contcor1"
+options$descriptivePlotSeparateLines <- "facGender"
 options$singleModelTerms <- list(list(components = "facGender"), list(components = "contcor1"))
 set.seed(1)
 results <- jaspTools::runAnalysis("AncovaBayesian", "debug.csv", options)
@@ -172,7 +172,7 @@ options$modelTerms <- list(
 options$posteriorEstimates <- TRUE
 options$singleModelTerms <- list(list(components = "contcor1"), list(components = "facGender"))
 set.seed(1)
-results <- runAnalysis("AncovaBayesian", "test.csv", options)
+results <- jaspTools::runAnalysis("AncovaBayesian", "test.csv", options)
 
 test_that("Model Comparison table results with interactions match", {
 	table <- results[["results"]][["tableModelComparison"]][["data"]]

--- a/tests/testthat/test-anova.R
+++ b/tests/testthat/test-anova.R
@@ -22,7 +22,7 @@ test_that("Main table results match", {
   options$effectSizeEtaSquared <- TRUE
   options$effectSizeOmegaSquared <- TRUE
   options$effectSizePartialEtaSquared <- TRUE
-  options$VovkSellkeMPR <- TRUE
+  options$vovkSellke <- TRUE
 
   refTables <- list(
     type1 = list("facFive", 181.151987151139, 4, 45.2879967877848, 1.82424792091397,
@@ -69,7 +69,7 @@ test_that("Homogeneity of Variances table results match", {
   options$fixedFactors <- "facExperim"
   options$modelTerms <- list(list(components="facExperim"))
   options$homogeneityTests <- TRUE
-  options$VovkSellkeMPR <- TRUE
+  options$vovkSellke <- TRUE
   results <- jaspTools::runAnalysis("Anova", "test.csv", options)
   table <- results[["results"]][["anovaContainer"]][["collection"]][["anovaContainer_assumptionsContainer"]][["collection"]][["anovaContainer_assumptionsContainer_leveneTable"]][["data"]]
   jaspTools::expect_equal_tables(table, list(3.1459013381035, 1, 98, 0.0792241296904395, 1.83142365040653))
@@ -81,7 +81,7 @@ test_that("Contrasts table results match", {
   options <- initClassicalAnovaOptions("Anova")
   options$dependent <- "contNormal"
   options$fixedFactors <- "facFive"
-  options$confidenceIntervalsContrast <- TRUE
+  options$contrastCi <- TRUE
   options$modelTerms <- list(list(components="facFive"))
 
   refTables <- list(
@@ -138,14 +138,14 @@ test_that("Post Hoc table results match", {
   options$dependent <- "contNormal"
   options$fixedFactors <- "contBinom"
   options$modelTerms <- list(list(components="contBinom"))
-  options$postHocTestEffectSize <- TRUE
-  options$postHocTestsBonferroni <- TRUE
-  options$postHocTestsHolm <- TRUE
-  options$postHocTestsScheffe <- TRUE
-  options$postHocTestsTukey <- TRUE
-  options$postHocTestsSidak <- TRUE
-  options$confidenceIntervalsPostHoc <- TRUE
-  options$postHocTestsVariables <- "contBinom"
+  options$postHocTypeStandardEffectSize <- TRUE
+  options$postHocCorrectionBonferroni <- TRUE
+  options$postHocCorrectionHolm <- TRUE
+  options$postHocCorrectionScheffe <- TRUE
+  options$postHocCorrectionTukey <- TRUE
+  options$postHocCorrectionSidak <- TRUE
+  options$postHocCi <- TRUE
+  options$postHocTerms <- "contBinom"
   results <- jaspTools::runAnalysis("Anova", "test.csv", options)
   table <- results$results$anovaContainer$collection$anovaContainer_postHocContainer$collection$anovaContainer_postHocContainer_postHocStandardContainer$collection$anovaContainer_postHocContainer_postHocStandardContainer_contBinom$data
   jaspTools::expect_equal_tables(table,
@@ -161,8 +161,8 @@ test_that("Marginal Means table results match", {
   options$dependent <- "contNormal"
   options$fixedFactors <- "contBinom"
   options$modelTerms <- list(list(components="contBinom"))
-  options$marginalMeansCompareMainEffects <- TRUE
-  options$marginalMeansTerms <- "contBinom"
+  options$marginalMeanComparedToZero <- TRUE
+  options$marginalMeanTerms <- "contBinom"
 
   # added df to contrast table
   refTables <- list(
@@ -181,7 +181,7 @@ test_that("Marginal Means table results match", {
   )
 
   for (adjustment in c("none", "Bonferroni", "Sidak")) {
-    options$marginalMeansCIAdjustment <- adjustment
+    options$marginalMeanCiCorrection <- adjustment
     results <- jaspTools::runAnalysis("Anova", "test.csv", options)
     table <- results[["results"]]$anovaContainer$collection$anovaContainer_marginalMeansContainer$collection[[1]]$data
     jaspTools::expect_equal_tables(table, refTables[[adjustment]], label=paste("Table with CI adjustment", adjustment))
@@ -225,16 +225,16 @@ test_that("Descriptives plots match", {
     list(components="contBinom"),
     list(components=c("facFive", "contBinom"))
   )
-  options$plotHorizontalAxis <- "contBinom"
-  options$plotSeparateLines <- "facFive"
-  options$plotErrorBars <- TRUE
-  options$confidenceIntervalInterval <- 0.90
-  options$errorBarType <- "confidenceInterval"
+  options$descriptivePlotHorizontalAxis <- "contBinom"
+  options$descriptivePlotSeparateLines <- "facFive"
+  options$descriptivePlotErrorBar <- TRUE
+  options$descriptivePlotCiLevel <- 0.90
+  options$descriptivePlotErrorBarType <- "ci"
   results <- jaspTools::runAnalysis("Anova", "test.csv", options)
   testPlot <- results$state$figures[[1]]$obj
   jaspTools::expect_equal_plots(testPlot, "descriptives-ci")
 
-  options$errorBarType <- "standardError"
+  options$descriptivePlotErrorBarType <- "se"
   results <- jaspTools::runAnalysis("Anova", "test.csv", options)
   testPlot <-  results$state$figures[[1]]$obj
   jaspTools::expect_equal_plots(testPlot, "descriptives-se")
@@ -250,14 +250,14 @@ test_that("Raincloud plots match", {
     list(components="contBinom"),
     list(components=c("facFive", "contBinom"))
   )
-  options$rainCloudPlotsHorizontalAxis <- "contBinom"
-  options$rainCloudPlotsSeparatePlots <- "facFive"
+  options$rainCloudHorizontalAxis <- "contBinom"
+  options$rainCloudSeparatePlots <- "facFive"
   set.seed(1)
   results <- jaspTools::runAnalysis("Anova", "test.csv", options)
   testPlot <- results$state$figures[[1]]$obj
   jaspTools::expect_equal_plots(testPlot, "raincloud-plots-vertical")
 
-  options$rainCloudPlotsHorizontalDisplay <- TRUE
+  options$rainCloudHorizontalDisplay <- TRUE
   set.seed(1)
   results <- jaspTools::runAnalysis("Anova", "test.csv", options)
   testPlot <-  results$state$figures[[1]]$obj
@@ -272,11 +272,11 @@ test_that("Simple Main Effects table results match", {
     list(components="facExperim"),
     list(components="facFive")
   )
-  options$simpleFactor <- "facExperim"
-  options$moderatorFactorOne <- "facFive"
-  options$moderatorFactorTwo <- ""
+  options$simpleMainEffectFactor <- "facExperim"
+  options$simpleMainEffectModeratorFactorOne <- "facFive"
+  options$simpleMainEffectModeratorFactorTwo <- ""
   options$homogeneityTests <- TRUE
-  options$VovkSellkeMPR <- TRUE
+  options$vovkSellke <- TRUE
   results <- jaspTools::runAnalysis("Anova", "debug.csv", options)
   table <- results$results$anovaContainer$collection$anovaContainer_simpleEffectsContainer$collection$anovaContainer_simpleEffectsContainer_simpleEffectsTable$data
   jaspTools::expect_equal_tables(table, list(1, 0.350864897951646, 1, 0.350864897951646, 0.310783783968887,
@@ -293,7 +293,7 @@ test_that("Nonparametric table results match", {
   options <- initClassicalAnovaOptions("Anova")
   options$dependent <- "contNormal"
   options$fixedFactors <- c( "facFive", "facExperim")
-  options$kruskalVariablesAssigned <- c( "facFive", "facExperim")
+  options$kruskalWallisFactors <- c( "facFive", "facExperim")
   options$modelTerms <- list(
     list(components="facExperim"),
     list(components="facFive")
@@ -351,11 +351,11 @@ options$customContrasts <- list()
 options$dependent <- "Sepal.Length"
 options$fixedFactors <- "Species"
 options$modelTerms <- list(list(components = "Species"))
-options$postHocTestsVariables <- list(list(variable = "Species"))
-options$rainCloudPlotsHorizontalAxis <- ""
-options$rainCloudPlotsHorizontalDisplay <- FALSE
-options$rainCloudPlotsLabelYAxis <- ""
-options$rainCloudPlotsSeparatePlots <- ""
+options$postHocTerms <- list(list(variable = "Species"))
+options$rainCloudHorizontalAxis <- ""
+options$rainCloudHorizontalDisplay <- FALSE
+options$rainCloudYAxisLabel <- ""
+options$rainCloudSeparatePlots <- ""
 
 # dataset is created from:
 # dd <- read.csv("~/github/jasp-desktop/Resources/Data Sets/Data Library/10. Machine Learning/iris.csv")
@@ -372,7 +372,7 @@ dataset <- data.frame(
 )
 
 set.seed(1)
-results <- runAnalysis("Anova", dataset, options)
+results <- jaspTools::runAnalysis("Anova", dataset, options)
 
 test_that("Post Hoc Comparisons - Species table results match and contrast names do not contain commas", {
    table <- results[["results"]][["anovaContainer"]][["collection"]][["anovaContainer_postHocContainer"]][["collection"]][["anovaContainer_postHocContainer_postHocStandardContainer"]][["collection"]][["anovaContainer_postHocContainer_postHocStandardContainer_Species"]][["data"]]
@@ -404,8 +404,8 @@ test_that("Field - Chapter 4 results match", {
   options$modelTerms <- list(list(components = "Dose"))
 
   options$homogeneityCorrections <- TRUE
-  options$homogeneityBrown <- TRUE
-  options$homogeneityWelch <- TRUE
+  options$homogeneityCorrectionBrown <- TRUE
+  options$homogeneityCorrectionWelch <- TRUE
 
   results <- jaspTools::runAnalysis("Anova", "Puppies Dummy.csv", options)
   table <- results[["results"]][["anovaContainer"]][["collection"]][["anovaContainer_anovaTable"]][["data"]]
@@ -433,12 +433,12 @@ test_that("Field - Chapter 5 results match", {
   options$contrasts <- list(
     list(contrast = "Helmert", variable = "Dose")
   )
-  options$confidenceIntervalsContrast <- TRUE
+  options$contrastCi <- TRUE
 
-  options$postHocTestsVariables <- "Dose"
-  options$postHocTestsTypeGames <- TRUE
-  options$postHocTestsTypeDunnett <- TRUE
-  options$confidenceIntervalsPostHoc <- TRUE
+  options$postHocTerms <- "Dose"
+  options$postHocTypeGames <- TRUE
+  options$postHocTypeDunnet <- TRUE
+  options$postHocCi <- TRUE
   results <- jaspTools::runAnalysis("Anova", "Puppies Dummy.csv", options)
 
   # contrast
@@ -493,20 +493,20 @@ test_that("Field - Chapter 7 results match", {
     list(contrast = "none", variable = "FaceType"),
     list(contrast = "Helmert", variable = "Alcohol")
   )
-  options$confidenceIntervalsContrast <- TRUE
+  options$contrastCi <- TRUE
 
-  options$postHocTestsVariables <- "Alcohol"
-  options$postHocTestsBonferroni <- TRUE
-  options$confidenceIntervalsPostHoc <- TRUE
-  options$postHocTestsBootstrapping <- TRUE
-  options$postHocTestsBootstrappingReplicates <- 500
+  options$postHocTerms <- "Alcohol"
+  options$postHocCorrectionBonferroni <- TRUE
+  options$postHocCi <- TRUE
+  options$postHocTypeStandardBootstrap <- TRUE
+  options$postHocTypeStandardBootstrapSamples <- 500
 
-  options$marginalMeansTerms <- list(
+  options$marginalMeanTerms <- list(
     list(components = c("FaceType", "Alcohol"))
   )
-  options$marginalMeansBootstrapping <- TRUE
-  options$marginalMeansBootstrappingReplicates <- 500
-  options$marginalMeansCompareMainEffects <- FALSE
+  options$marginalMeanBootstrap <- TRUE
+  options$marginalMeanBootstrapSamples <- 500
+  options$marginalMeanComparedToZero <- FALSE
   set.seed(1)
   results <- jaspTools::runAnalysis("Anova", "Beer Goggles.csv", options)
 
@@ -557,7 +557,7 @@ test_that("ANOVA - factor level with zero variance works and Welch homogeneity c
   options <- initClassicalAnovaOptions("Anova")
   options$dependent <- "value"
   options$fixedFactors <- "group"
-  options$homogeneityWelch <- TRUE
+  options$homogeneityCorrectionWelch <- TRUE
   options$modelTerms <- list(list(components = "group"))
 
   dataset <- data.frame(
@@ -566,7 +566,7 @@ test_that("ANOVA - factor level with zero variance works and Welch homogeneity c
   )
 
   set.seed(1)
-  results <- runAnalysis("Anova", dataset, options)
+  results <- jaspTools::runAnalysis("Anova", dataset, options)
   table <- results[["results"]][["anovaContainer"]][["collection"]][["anovaContainer_anovaTable"]][["data"]]
   jaspTools::expect_equal_tables(table,
                                  list("TRUE", 3, 2.67905056759546, 1.888, 0.0985227092069956, 5.664,
@@ -592,32 +592,28 @@ options$customContrasts <- list()
 options$dependent <- "Age"
 options$fixedFactors <- "Group"
 options$modelTerms <- list(list(components = "Group"))
-options$rainCloudPlotsHorizontalAxis <- ""
-options$rainCloudPlotsHorizontalDisplay <- FALSE
-options$rainCloudPlotsLabelYAxis <- ""
-options$rainCloudPlotsSeparatePlots <- ""
-options$restrictedBootstrapping <- FALSE
-options$restrictedBootstrappingConfidenceIntervalLevel <- 0.95
-options$restrictedBootstrappingReplicates <- 1000
-options$restrictedIncludeIntercept <- FALSE
-options$restrictedInformedHypothesisTestByDefault <- FALSE
-options$restrictedMarginalMeansByDefault <- FALSE
+options$restrictedBootstrap <- FALSE
+options$restrictedBootstrapCiLevel <- 0.95
+options$restrictedBootstrapSamples <- 1000
+options$restrictedInterceptInclusion <- FALSE
+options$restrictedInformedHypothesisTestForAllModels <- FALSE
+options$restrictedMarginalMeanForAllModels <- FALSE
 options$restrictedModelComparison <- "none"
 options$restrictedModelComparisonCoefficients <- FALSE
-options$restrictedModelComparisonHighlightCoefficients <- TRUE
+options$restrictedModelComparisonCoefficientsHighlight <- TRUE
 options$restrictedModelComparisonMatrix <- FALSE
 options$restrictedModelComparisonReference <- "Model 1"
 options$restrictedModelComparisonWeights <- FALSE
-options$restrictedModelMarginalMeansTerms <- list()
-options$restrictedModelShowAvailableCoefficients <- TRUE
-options$restrictedModelSummaryByDefault <- FALSE
-options$restrictedModels <- list(list(informedHypothesisTest = TRUE, marginalMeans = FALSE,
-                                      modelName = "Model 1", modelSummary = TRUE, restrictionSyntax = "GroupActive < GroupPassive\nGroupPassive < GroupNo"))
-options$restrictedSE <- "standard"
+options$restrictedModelMarginalMeanTerms <- list()
+options$restrictedAvailableCoefficients <- TRUE
+options$restrictedModelSummaryForAllModels <- FALSE
+options$restrictedModels <- list(list(informedHypothesisTest = TRUE, marginalMean = FALSE,
+                                      name = "Model 1", summary = TRUE, syntax = "GroupActive < GroupPassive\nGroupPassive < GroupNo"))
+options$restrictedHeterogeneityCorrection <- "none"
 set.seed(1)
 dataset <- read.csv("ZelazoKolb1972.csv")
 dataset <- subset(dataset, Group != "Control")
-results <- runAnalysis("Anova", dataset, options)
+results <- jaspTools::runAnalysis("Anova", dataset, options)
 
 
 ### see https://restriktor.org/tutorial/restriktor.html for comparison ----
@@ -666,32 +662,28 @@ options$customContrasts <- list()
 options$dependent <- "Age"
 options$fixedFactors <- "Group"
 options$modelTerms <- list(list(components = "Group"))
-options$rainCloudPlotsHorizontalAxis <- ""
-options$rainCloudPlotsHorizontalDisplay <- FALSE
-options$rainCloudPlotsLabelYAxis <- ""
-options$rainCloudPlotsSeparatePlots <- ""
-options$restrictedBootstrapping <- FALSE
-options$restrictedBootstrappingConfidenceIntervalLevel <- 0.95
-options$restrictedBootstrappingReplicates <- 1000
-options$restrictedIncludeIntercept <- FALSE
-options$restrictedInformedHypothesisTestByDefault <- FALSE
-options$restrictedMarginalMeansByDefault <- FALSE
+options$restrictedBootstrap <- FALSE
+options$restrictedBootstrapCiLevel <- 0.95
+options$restrictedBootstrapSamples <- 1000
+options$restrictedInterceptInclusion <- FALSE
+options$restrictedInformedHypothesisTestForAllModels <- FALSE
+options$restrictedMarginalMeanForAllModels <- FALSE
 options$restrictedModelComparison <- "none"
 options$restrictedModelComparisonCoefficients <- FALSE
-options$restrictedModelComparisonHighlightCoefficients <- TRUE
+options$restrictedModelComparisonCoefficientsHighlight <- TRUE
 options$restrictedModelComparisonMatrix <- FALSE
 options$restrictedModelComparisonReference <- "Model 1"
 options$restrictedModelComparisonWeights <- FALSE
-options$restrictedModelMarginalMeansTerms <- list()
-options$restrictedModelShowAvailableCoefficients <- FALSE
-options$restrictedModelSummaryByDefault <- FALSE
-options$restrictedModels <- list(list(informedHypothesisTest = TRUE, marginalMeans = FALSE,
-                                      modelName = "Model 1", modelSummary = TRUE, restrictionSyntax = "GroupActive  < GroupPassive\nGroupPassive < GroupControl\nGroupControl < GroupNo"),
-                                 list(informedHypothesisTest = TRUE, marginalMeans = FALSE,
-                                      modelName = "Model 2", modelSummary = TRUE, restrictionSyntax = "(GroupPassive - GroupActive)  / 1.516 > 0.2\n(GroupControl - GroupPassive) / 1.516 > 0.2\n(GroupNo      - GroupControl) / 1.516 > 0.2"))
-options$restrictedSE <- "standard"
+options$restrictedModelMarginalMeanTerms <- list()
+options$restrictedAvailableCoefficients <- FALSE
+options$restrictedModelSummaryForAllModels <- FALSE
+options$restrictedModels <- list(list(informedHypothesisTest = TRUE, marginalMean = FALSE,
+                                      name = "Model 1", summary = TRUE, syntax = "GroupActive  < GroupPassive\nGroupPassive < GroupControl\nGroupControl < GroupNo"),
+                                 list(informedHypothesisTest = TRUE, marginalMean = FALSE,
+                                      name = "Model 2", summary = TRUE, syntax = "(GroupPassive - GroupActive)  / 1.516 > 0.2\n(GroupControl - GroupPassive) / 1.516 > 0.2\n(GroupNo      - GroupControl) / 1.516 > 0.2"))
+options$restrictedHeterogeneityCorrection <- "none"
 set.seed(1)
-results <- runAnalysis("Anova", "ZelazoKolb1972.csv", options)
+results <- jaspTools::runAnalysis("Anova", "ZelazoKolb1972.csv", options)
 
 
 ### see https://restriktor.org/tutorial/example1.html for comparison ----
@@ -762,34 +754,30 @@ options$customContrasts <- list()
 options$dependent <- "Anger"
 options$fixedFactors <- "Group"
 options$modelTerms <- list(list(components = "Group"))
-options$rainCloudPlotsHorizontalAxis <- ""
-options$rainCloudPlotsHorizontalDisplay <- FALSE
-options$rainCloudPlotsLabelYAxis <- ""
-options$rainCloudPlotsSeparatePlots <- ""
-options$restrictedBootstrapping <- FALSE
-options$restrictedBootstrappingConfidenceIntervalLevel <- 0.95
-options$restrictedBootstrappingReplicates <- 1000
-options$restrictedIncludeIntercept <- FALSE
-options$restrictedInformedHypothesisTestByDefault <- FALSE
-options$restrictedMarginalMeansByDefault <- FALSE
+options$restrictedBootstrap <- FALSE
+options$restrictedBootstrapCiLevel <- 0.95
+options$restrictedBootstrapSamples <- 1000
+options$restrictedInterceptInclusion <- FALSE
+options$restrictedInformedHypothesisTestForAllModels <- FALSE
+options$restrictedMarginalMeanForAllModels <- FALSE
 options$restrictedModelComparison <- "unconstrained"
 options$restrictedModelComparisonCoefficients <- FALSE
-options$restrictedModelComparisonHighlightCoefficients <- TRUE
+options$restrictedModelComparisonCoefficientsHighlight <- TRUE
 options$restrictedModelComparisonMatrix <- FALSE
 options$restrictedModelComparisonReference <- "Model 2"
 options$restrictedModelComparisonWeights <- FALSE
-options$restrictedModelMarginalMeansTerms <- list()
-options$restrictedModelShowAvailableCoefficients <- FALSE
-options$restrictedModelSummaryByDefault <- FALSE
-options$restrictedModels <- list(list(informedHypothesisTest = FALSE, marginalMeans = FALSE,
-                                      modelName = "Model 1", modelSummary = FALSE, restrictionSyntax = "GroupNo = GroupPhysical\nGroupPhysical = GroupBehavioral\nGroupBehavioral = GroupBoth"),
-                                 list(informedHypothesisTest = FALSE, marginalMeans = FALSE,
-                                      modelName = "Model 2", modelSummary = FALSE, restrictionSyntax = "GroupNo < GroupPhysical\nGroupPhysical = GroupBehavioral\nGroupBehavioral < GroupBoth"),
-                                 list(informedHypothesisTest = FALSE, marginalMeans = FALSE,
-                                      modelName = "Model 3", modelSummary = FALSE, restrictionSyntax = "GroupNo < GroupPhysical\nGroupPhysical < GroupBehavioral\nGroupBehavioral < GroupBoth"))
-options$restrictedSE <- "standard"
+options$restrictedModelMarginalMeanTerms <- list()
+options$restrictedAvailableCoefficients <- FALSE
+options$restrictedModelSummaryForAllModels <- FALSE
+options$restrictedModels <- list(list(informedHypothesisTest = FALSE, marginalMean = FALSE,
+                                      name = "Model 1", summary = FALSE, syntax = "GroupNo = GroupPhysical\nGroupPhysical = GroupBehavioral\nGroupBehavioral = GroupBoth"),
+                                 list(informedHypothesisTest = FALSE, marginalMean = FALSE,
+                                      name = "Model 2", summary = FALSE, syntax = "GroupNo < GroupPhysical\nGroupPhysical = GroupBehavioral\nGroupBehavioral < GroupBoth"),
+                                 list(informedHypothesisTest = FALSE, marginalMean = FALSE,
+                                      name = "Model 3", summary = FALSE, syntax = "GroupNo < GroupPhysical\nGroupPhysical < GroupBehavioral\nGroupBehavioral < GroupBoth"))
+options$restrictedHeterogeneityCorrection <- "none"
 set.seed(1)
-results <- runAnalysis("Anova", "AngerManagement.csv", options)
+results <- jaspTools::runAnalysis("Anova", "AngerManagement.csv", options)
 
 test_that("Ordinal restrictions: Model Comparison Table results match", {
   table <- results[["results"]][["anovaContainer"]][["collection"]][["anovaContainer_ordinalRestrictions"]][["collection"]][["anovaContainer_ordinalRestrictions_modelComparison"]][["collection"]][["anovaContainer_ordinalRestrictions_modelComparison_comparisonTable"]][["data"]]

--- a/tests/testthat/test-anovarepeatedmeasures.R
+++ b/tests/testthat/test-anovarepeatedmeasures.R
@@ -524,7 +524,7 @@ test_that("Effect Size Calculation correct", {
   options$effectSizeEtaSquared <- TRUE
   options$effectSizePartialEtaSquared <- TRUE
   options$effectSizeOmegaSquared <- TRUE
-  options$effectSizeGenEtaSquared <- TRUE
+  options$effectSizeGeneralEtaSquared <- TRUE
 
   results <- jaspTools::runAnalysis(name = "AnovaRepeatedMeasures",
                             dataset = "AnovaRepeatedMeasuresOneWay.csv",

--- a/tests/testthat/test-anovarepeatedmeasures.R
+++ b/tests/testthat/test-anovarepeatedmeasures.R
@@ -45,9 +45,9 @@ initOpts <- function(){
 test_that("Within subjects table results match", {
   options <- initOpts()
 
-  options$sphericityNone <- TRUE
-  options$sphericityHuynhFeldt <- TRUE
-  options$sphericityGreenhouseGeisser <- TRUE
+  options$sphericityCorrectionNone <- TRUE
+  options$sphericityCorrectionHuynhFeldt <- TRUE
+  options$sphericityCorrectionGreenhouseGeisser <- TRUE
 
   results <- jaspTools::runAnalysis(name = "AnovaRepeatedMeasures", dataset = "AnovaRepeatedMeasures.csv",
                             options = options)
@@ -112,15 +112,15 @@ test_that("Sphericity Assumptions table match (Field Chapter 8)", {
 test_that("Post-hoc tests match (Field Chapter 8)", {
   options <- initOpts()
 
-  options$postHocTestsVariables <- list(list(components = "Drink"),
+  options$postHocTerms <- list(list(components = "Drink"),
                                         list(components = "Imagery"),
                                         list(components = c("Drink", "Imagery")))
-  options$postHocTestEffectSize <- TRUE
-  options$postHocTestsBonferroni <- TRUE
-  options$postHocTestsHolm <- TRUE
+  options$postHocEffectSize <- TRUE
+  options$postHocCorrectionBonferroni <- TRUE
+  options$postHocCorrectionHolm <- TRUE
 
-  options$postHocTestPooledError <- FALSE
-  options$confidenceIntervalsPostHoc <- TRUE
+  options$postHocPooledError <- FALSE
+  options$postHocCi <- TRUE
   results <- jaspTools::runAnalysis(name = "AnovaRepeatedMeasures", dataset = "AnovaRepeatedMeasures.csv",
                             options = options)
 
@@ -304,9 +304,9 @@ test_that("Field - Chapter 8 marginal means match", {
   # compared to SPSS, we pool the standard errors in marginal means
   options <- initOpts()
 
-  options$marginalMeansTerms <- options$withinModelTerms[3]
-  options$marginalMeansBootstrapping <- TRUE
-  options$marginalMeansBootstrappingReplicates <- 500
+  options$marginalMeanTerms <- options$withinModelTerms[3]
+  options$marginalMeanBootstrap <- TRUE
+  options$marginalMeanBootstrapSamples <- 500
   set.seed(1)
   results <- jaspTools::runAnalysis("AnovaRepeatedMeasures", dataset = "AnovaRepeatedMeasures.csv",
                             options = options)
@@ -442,33 +442,35 @@ test_that("Descriptives Plots match", {
   options <- initOpts()
   options$sphericityCorrections <- TRUE
   options$sphericityTests <- TRUE
-  options$plotHorizontalAxis <- "Charisma"
-  options$plotSeparateLines <- "gender"
-  options$plotErrorBars <- TRUE
+  options$descriptivePlotHorizontalAxis <- "Charisma"
+  options$descriptivePlotSeparateLines <- "gender"
+  options$descriptivePlotErrorBar <- TRUE
 
-  options$usePooledStandErrorCI <- FALSE
-  options$errorBarType <- "confidenceInterval"
-  results <- jaspTools::runAnalysis(name = "AnovaRepeatedMeasures",
-                            dataset = "AnovaMixedEffects.csv", options = options)
+  options$descriptivePlotErrorBarPooled <- FALSE
+  options$descriptivePlotErrorBarType <- "ci"
+  results <- jaspTools::runAnalysis(
+    name    = "AnovaRepeatedMeasures",
+    dataset = "AnovaMixedEffects.csv",
+    options = options)
   descPlot <-  results$state$figures[[1]]$obj
   jaspTools::expect_equal_plots(descPlot, "mixedRMANOVA1")
 
-  options$usePooledStandErrorCI <- TRUE
-  options$errorBarType <- "confidenceInterval"
+  options$descriptivePlotErrorBarPooled <- TRUE
+  options$descriptivePlotErrorBarType <- "ci"
   results <- jaspTools::runAnalysis(name = "AnovaRepeatedMeasures",
                             dataset = "AnovaMixedEffects.csv", options = options)
   descPlot <-  results$state$figures[[1]]$obj
   jaspTools::expect_equal_plots(descPlot, "mixedRMANOVA2")
 
-  options$usePooledStandErrorCI <- FALSE
-  options$errorBarType <- "standardError"
+  options$descriptivePlotErrorBarPooled <- FALSE
+  options$descriptivePlotErrorBarType <- "se"
   results <- jaspTools::runAnalysis(name = "AnovaRepeatedMeasures",
                             dataset = "AnovaMixedEffects.csv", options = options)
   descPlot <-  results$state$figures[[1]]$obj
   jaspTools::expect_equal_plots(descPlot, "mixedRMANOVA3")
 
-  options$usePooledStandErrorCI <- TRUE
-  options$errorBarType <- "standardError"
+  options$descriptivePlotErrorBarPooled <- TRUE
+  options$descriptivePlotErrorBarType <- "se"
   results <- jaspTools::runAnalysis(name = "AnovaRepeatedMeasures",
                             dataset = "AnovaMixedEffects.csv", options = options)
   descPlot <-  results$state$figures[[1]]$obj
@@ -480,11 +482,13 @@ test_that("Raincloud Plots match", {
   options <- initOpts()
   options$sphericityCorrections <- TRUE
   options$sphericityTests <- TRUE
-  options$rainCloudPlotsHorizontalAxis <- "Charisma"
-  options$rainCloudPlotsSeparatePlots <- "gender"
+  options$rainCloudHorizontalAxis <- "Charisma"
+  options$rainCloudSeparatePlots <- "gender"
   set.seed(1)
-  results <- jaspTools::runAnalysis(name = "AnovaRepeatedMeasures",
-                            dataset = "AnovaMixedEffects.csv", options = options)
+  results <- jaspTools::runAnalysis(
+    name    = "AnovaRepeatedMeasures",
+    dataset = "AnovaMixedEffects.csv",
+    options = options)
   testPlot <-  results$state$figures[[1]]$obj
   jaspTools::expect_equal_plots(testPlot, "raincloud-plots")
 })
@@ -493,8 +497,8 @@ test_that("Raincloud Plots match for between subjects", {
   options <- initOpts()
   options$sphericityCorrections <- TRUE
   options$sphericityTests <- TRUE
-  options$rainCloudPlotsHorizontalAxis <- "gender"
-  options$rainCloudPlotsSeparatePlots <- "Charisma"
+  options$rainCloudHorizontalAxis <- "gender"
+  options$rainCloudSeparatePlots <- "Charisma"
   set.seed(1)
   results <- jaspTools::runAnalysis(name = "AnovaRepeatedMeasures",
                                     dataset = "AnovaMixedEffects.csv", options = options)
@@ -545,13 +549,13 @@ test_that("Simple Effects table match", {
     list(components = "gender")
   )
 
-  options$simpleFactor <- "Looks"
-  options$moderatorFactorOne <- "gender"
-  options$moderatorFactorTwo <- "Charisma"
+  options$simpleMainEffectFactor <- "Looks"
+  options$simpleMainEffectModeratorFactorOne <- "gender"
+  options$simpleMainEffectModeratorFactorTwo <- "Charisma"
 
-  results <- jaspTools::runAnalysis(name = "AnovaRepeatedMeasures",
-                            dataset = "AnovaMixedEffects.csv",
-                            options = options)
+  results <- jaspTools::runAnalysis(name    = "AnovaRepeatedMeasures",
+                                    dataset = "AnovaMixedEffects.csv",
+                                    options = options)
 
   refTable <- list("Female", "High", 42.4666666666668, 2, 21.2333333333334, 0.639629588307488,
                    0.539062933641058, "TRUE", "Female", "Some", 6444.46666666667, 2,
@@ -635,15 +639,15 @@ test_that("Field - Chapter 8 results match", {
   )
 
   options$sphericityTests <- TRUE
-  options$sphericityNone <- TRUE
-  options$sphericityHuynhFeldt <- TRUE
-  options$sphericityGreenhouseGeisser <- TRUE
+  options$sphericityCorrectionNone <- TRUE
+  options$sphericityCorrectionHuynhFeldt <- TRUE
+  options$sphericityCorrectionGreenhouseGeisser <- TRUE
 
-  options$postHocTestsVariables <- "Animal"
-  options$postHocTestPooledError <- FALSE
-  options$postHocTestsBonferroni <- TRUE
-  options$confidenceIntervalsPostHoc <- TRUE
-  options$postHocTestEffectSize <- TRUE
+  options$postHocTerms <- "Animal"
+  options$postHocPooledError <- FALSE
+  options$postHocCorrectionBonferroni <- TRUE
+  options$postHocCi <- TRUE
+  options$postHocEffectSize <- TRUE
 
   results <- jaspTools::runAnalysis(name = "AnovaRepeatedMeasures",
                             dataset = "AnovaRepeatedMeasuresOneWay.csv",
@@ -702,7 +706,7 @@ test_that("Field - Chapter 9 match",  {
 
   options$sphericityTests <- TRUE
 
-  options$marginalMeansTerms <- list(
+  options$marginalMeanTerms <- list(
     list(components = "Charisma"),
     list(components = "Looks"),
     list(components = "gender"),
@@ -823,28 +827,24 @@ test_that("Field - Chapter 9 match",  {
 options <- initClassicalAnovaOptions("AnovaRepeatedMeasures")
 options$contrasts <- list(list(contrast = "none", variable = "Drink"))
 options$customContrasts <- list()
-options$labelYAxis <- "Alcohol Attitudes"
-options$moderatorFactorOne <- "Drink"
-options$plotErrorBars <- TRUE
-options$plotHorizontalAxis <- "Drink"
-options$plotSeparateLines <- "Imagery"
-options$postHocTestPooledError <- FALSE
-options$postHocTestsBonferroni <- TRUE
-options$postHocTestsHolm <- FALSE
-options$rainCloudPlotsHorizontalAxis <- ""
-options$rainCloudPlotsHorizontalDisplay <- FALSE
-options$rainCloudPlotsLabelYAxis <- ""
-options$rainCloudPlotsSeparatePlots <- ""
+options$descriptivePlotYAxisLabel <- "Alcohol Attitudes"
+options$simpleMainEffectModeratorFactorOne <- "Drink"
+options$descriptivePlotErrorBar <- TRUE
+options$descriptivePlotHorizontalAxis <- "Drink"
+options$descriptivePlotSeparateLines <- "Imagery"
+options$postHocPooledError <- FALSE
+options$postHocCorrectionBonferroni <- TRUE
+options$postHocCorrectionHolm <- FALSE
 options$repeatedMeasuresCells <- c("beerpos", "beerneut", "beerneg", "winepos", "wineneut", "wineneg", "waterpos", "waterneu", "waterneg")
 options$repeatedMeasuresFactors <- list(list(levels = c("Beer", "Wine", "Water"), name = "Drink"),
     list(levels = c("Positive", "Neutral", "Negative"), name = "Imagery"))
-options$simpleFactor <- "Imagery"
-options$sphericityGreenhouseGeisser <- TRUE
-options$sphericityHuynhFeldt <- TRUE
+options$simpleMainEffectFactor <- "Imagery"
+options$sphericityCorrectionGreenhouseGeisser <- TRUE
+options$sphericityCorrectionHuynhFeldt <- TRUE
 options$sphericityTests <- TRUE
 options$withinModelTerms <- list(list(components = "Drink"))
 set.seed(1)
-results <- runAnalysis("AnovaRepeatedMeasures", "Alcohol Attitudes.csv", options)
+results <- jaspTools::runAnalysis("AnovaRepeatedMeasures", "Alcohol Attitudes.csv", options)
 
 
 test_that("Test of Sphericity table results match", {
@@ -855,23 +855,19 @@ test_that("Test of Sphericity table results match", {
 # test model without interaction effect
 options <- initClassicalAnovaOptions("AnovaRepeatedMeasures")
 options$withinModelTerms <- list(list(components = "Drink"), list(components = "Imagery"))
-options$sphericityGreenhouseGeisser <- TRUE
-options$sphericityHuynhFeldt <- TRUE
-options$postHocTestPooledError <- FALSE
-options$postHocTestsHolm <- FALSE
-options$postHocTestsBonferroni <- TRUE
-options$labelYAxis <- "Alcohol Attitudes"
-options$plotErrorBars <- TRUE
+options$sphericityCorrectionGreenhouseGeisser <- TRUE
+options$sphericityCorrectionHuynhFeldt <- TRUE
+options$postHocPooledError <- FALSE
+options$postHocCorrectionHolm <- FALSE
+options$postHocCorrectionBonferroni <- TRUE
+options$descriptivePlotYAxisLabel <- "Alcohol Attitudes"
+options$descriptivePlotErrorBar <- TRUE
 options$contrasts <- list(list(contrast = "none", variable = "Drink"), list(contrast = "none", variable = "Imagery"))
 options$customContrasts <- list()
-options$rainCloudPlotsHorizontalAxis <- ""
-options$rainCloudPlotsHorizontalDisplay <- FALSE
-options$rainCloudPlotsLabelYAxis <- ""
-options$rainCloudPlotsSeparatePlots <- ""
 options$repeatedMeasuresCells <- c("beerpos", "beerneut", "beerneg", "winepos", "wineneut", "wineneg", "waterpos", "waterneu", "waterneg")
 options$repeatedMeasuresFactors <- list(list(levels = c("Beer", "Wine", "Water"), name = "Drink"), list(levels = c("Positive", "Neutral", "Negative"), name = "Imagery"))
 set.seed(1)
-results <- runAnalysis("AnovaRepeatedMeasures", "AnovaRepeatedMeasures.csv", options)
+results <- jaspTools::runAnalysis("AnovaRepeatedMeasures", "AnovaRepeatedMeasures.csv", options)
 
 
 test_that("No interaction: Between Subjects Effects table results match", {
@@ -928,36 +924,32 @@ options$contrasts <- list(list(contrast = "none", variable = "fac1"), list(contr
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        variable = c("facGender", "facExperim", "fac2")), list(contrast = "none",
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               variable = c("facGender", "facExperim", "fac1", "fac2")))
 options$customContrasts <- list()
-options$rainCloudPlotsHorizontalAxis <- ""
-options$rainCloudPlotsHorizontalDisplay <- FALSE
-options$rainCloudPlotsLabelYAxis <- ""
-options$rainCloudPlotsSeparatePlots <- ""
 options$repeatedMeasuresCells <- c("contNormal", "contGamma", "contcor1", "contcor2")
 options$repeatedMeasuresFactors <- list(list(levels = c("l1", "l2"), name = "fac1"), list(levels = c("a",
                                                                                                      "b"), name = "fac2"))
-options$restrictedBootstrapping <- TRUE
-options$restrictedBootstrappingConfidenceIntervalLevel <- 0.95
-options$restrictedBootstrappingReplicates <- 100
-options$restrictedIncludeIntercept <- TRUE
-options$restrictedInformedHypothesisTestByDefault <- FALSE
-options$restrictedMarginalMeansByDefault <- TRUE
+options$restrictedBootstrap <- TRUE
+options$restrictedBootstrapCiLevel <- 0.95
+options$restrictedBootstrapSamples <- 100
+options$restrictedInterceptInclusion <- TRUE
+options$restrictedInformedHypothesisTestForAllModels <- FALSE
+options$restrictedMarginalMeanForAllModels <- TRUE
 options$restrictedModelComparison <- "complement"
 options$restrictedModelComparisonCoefficients <- FALSE
-options$restrictedModelComparisonHighlightCoefficients <- TRUE
+options$restrictedModelComparisonCoefficientsHighlight <- TRUE
 options$restrictedModelComparisonMatrix <- FALSE
 options$restrictedModelComparisonReference <- "complement"
 options$restrictedModelComparisonWeights <- TRUE
-options$restrictedModelMarginalMeansTerms <- list(list(variable = c("fac1", "fac2")), list(variable = c("facGender",
-                                                                                                        "facExperim")))
-options$restrictedModelShowAvailableCoefficients <- TRUE
-options$restrictedModelSummaryByDefault <- TRUE
-options$restrictedModels <- list(list(informedHypothesisTest = FALSE, marginalMeans = TRUE,
-                                      modelName = "Model 1", modelSummary = TRUE, restrictionSyntax = "contNormal..Intercept. < 0\ncontcor2.facGenderm.facExperimexperimental > 0"))
-options$restrictedSE <- "standard"
+options$restrictedMarginalMeanTerms <- list(list(variable = c("fac1", "fac2")),
+                                            list(variable = c("facGender", "facExperim")))
+options$restrictedAvailableCoefficients <- TRUE
+options$restrictedModelSummaryForAllModels <- TRUE
+options$restrictedModels <- list(list(informedHypothesisTest = FALSE, marginalMean = TRUE,
+                                      name = "Model 1", summary = TRUE, syntax = "contNormal..Intercept. < 0\ncontcor2.facGenderm.facExperimexperimental > 0"))
+options$restrictedHeterogeneityCorrection <- "none"
 options$withinModelTerms <- list(list(components = "fac1"), list(components = "fac2"), list(
   components = c("fac1", "fac2")))
 set.seed(1)
-results <- runAnalysis("AnovaRepeatedMeasures", "test.csv", options)
+results <- jaspTools::runAnalysis("AnovaRepeatedMeasures", "test.csv", options)
 
 
 test_that("Ordinal restrictions: Within factor marginal means table results match", {

--- a/tests/testthat/test-anovarepeatedmeasuresbayesian.R
+++ b/tests/testthat/test-anovarepeatedmeasuresbayesian.R
@@ -324,8 +324,8 @@ test_that("Model Averaged Posterior Summary table results with interactions matc
 
 
 options <- initOpts("AnovaRepeatedMeasuresBayesian")
-options$plotHorizontalAxis <- "Drink"
-options$plotSeparateLines <- "Imagery"
+options$descriptivePlotHorizontalAxis <- "Drink"
+options$descriptivePlotSeparateLines <- "Imagery"
 options$repeatedMeasuresCells <- c("beerpos", "beerneut", "beerneg", "winepos", "wineneut", "wineneg", "waterpos", "waterneu", "waterneg")
 options$repeatedMeasuresFactors <- list(list(levels = c("Beer", "Wine", "Water"), name = "Drink"),
     list(levels = c("Positive", "Neutral", "Negative"), name = "Imagery"))

--- a/tests/testthat/test-verified-anova.R
+++ b/tests/testthat/test-verified-anova.R
@@ -57,7 +57,7 @@ test_that("Main table results match  R, SPSS, SAS and MiniTab 2-factor", {
 options <- initClassicalAnovaOptions("Anova")
 options$dependent <- "Score"
 options$fixedFactors <- "Treatment"
-options$kruskalVariablesAssigned <- "Treatment"
+options$kruskalWallisFactors <- "Treatment"
 
 options$modelTerms <- list(
   list(components="Treatment")


### PR DESCRIPTION
fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/1925
fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/1926
fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/1927

I still need to check once again that everything works fine in JASP, but @AlexanderLyNL you can check the new names already if you want.

also fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/1911 as a byproduct