### PR TITLE
Fix state dependencies for marginality options

### DIFF
--- a/R/commonAnovaBayesian.R
+++ b/R/commonAnovaBayesian.R
@@ -246,7 +246,7 @@
     modelTable <- .BANOVAinitModelComparisonTable(options)
     jaspResults[["tableModelComparison"]] <- modelTable
     return(list(analysisType = analysisType))
-  } else if (!is.null(stateObj) && .BANOVAmodelBFTypeOrOrderChanged(stateObj, options)) {
+  } else if (!is.null(stateObj) && .BANOVAmodelBFTypeOrOrderChanged(stateObj, options) && .BANOVAmarginalityOptionsUnchanged(stateObj, options)) {
 
     # if the statement above is TRUE then no new variables were added (or seed changed)
     # and the only change is in the Bayes factor type or the ordering
@@ -2941,6 +2941,12 @@ dBernoulliModelPrior <- function(k, n, prob = 0.5, log = FALSE) {
   !identical(state[["modelPriorOptions"]][.BANOVAmodelSpaceDependencies(options[["modelPrior"]])], options[.BANOVAmodelSpaceDependencies(options[["modelPrior"]])])
 }
 
+.BANOVAmarginalityOptionsUnchanged <- function(state, options) {
+  stateOpts <- state[["modelPriorOptions"]]
+  stateOpts[["enforcePrincipleOfMarginalityFixedEffects"]] == options[["enforcePrincipleOfMarginalityFixedEffects"]] &&
+    stateOpts[["enforcePrincipleOfMarginalityRandomSlopes"]] == options[["enforcePrincipleOfMarginalityRandomSlopes"]]
+}
+
 .BANOVAmodelBFTypeOrOrderChanged <- function(state, options) {
   nms <- c("fixedFactors", "modelTerms", "randomFactors", "covariates", "seed", "setSeed")
   nms <- intersect(names(options), nms) # excludes covariates for ANOVA
@@ -3069,8 +3075,9 @@ dBernoulliModelPrior <- function(k, n, prob = 0.5, log = FALSE) {
 
       for (j in which(ord > 1L)) {
         labelPieces <- strsplit(termLabels[j], ":")[[1L]]
+        sortedLabelPieces <- sort(labelPieces)
         for (k in seq_along(originalLabelsPieces))
-          if (all(sort(labelPieces) == originalLabelsPiecesSorted[[k]]))
+          if (identical(sortedLabelPieces, originalLabelsPiecesSorted[[k]]))
             termLabels[j] <- paste(originalLabelsPieces[[k]], collapse = ":")
       }
 


### PR DESCRIPTION
I noticed that the tables in ANOVA do not update when the marginality setting changes. Now they do, and they reuse any models that were computed using the previous marginality setting. You can verify this by toggling `For fixed effects`. Models that are present in both do not change bayes factor (e.g., green below), while models that are only present without marginality do change bayes factor slightly (due to resampling).

![image](https://user-images.githubusercontent.com/21319932/191478611-e3e46a3a-fdf3-463e-86b7-3262c8eb0deb.png)


The part about `sortedLabelPieces` fixes a warning/ error about comparing vectors of unequal length.