### PR TITLE
Limit number of models shown in Bayesian ANOVAs

### DIFF
--- a/R/commonAnovaBayesian.R
+++ b/R/commonAnovaBayesian.R
@@ -836,7 +836,7 @@ BANOVAcomputMatchedInclusion <- function(effectNames, effects.matrix, interactio
   table[["error %"]] <- 100 * table[["error %"]]
 
   if (!is.null(footnotes)) {
-    idxNan <- which(is.nan(as.matrix(table[-ncol(table)])), arr.ind = TRUE)
+    idxNan <- which(do.call(cbind, lapply(table[-ncol(table)], is.nan)), arr.ind = TRUE)
     footnotes[["rows"]] <- idxNan[, "row"]
     footnotes[["cols"]] <- idxNan[, "col"]
   }

--- a/R/commonAnovaBayesian.R
+++ b/R/commonAnovaBayesian.R
@@ -246,7 +246,10 @@
     modelTable <- .BANOVAinitModelComparisonTable(options)
     jaspResults[["tableModelComparison"]] <- modelTable
     return(list(analysisType = analysisType))
-  } else if (!is.null(stateObj) && .BANOVAmarginalityOptionsUnchanged(stateObj, options) && (.BANOVAmodelBFTypeOrOrderChanged(stateObj, options) || identical(stateObj[["shownTableSize"]], options[c("modelsShown", "numModelsShown")]))) {
+  } else if (!is.null(stateObj) &&
+             .BANOVAmodelTermsUnchanged(stateObj, options) &&
+             .BANOVAmarginalityOptionsUnchanged(stateObj, options) &&
+             (.BANOVAmodelBFTypeOrOrderChanged(stateObj, options) || identical(stateObj[["shownTableSize"]], options[c("modelsShown", "numModelsShown")]))) {
 
     # if the statement above is TRUE then no new variables were added (or seed changed)
     # and the only change is in the Bayes factor type, the ordering, or the number of models shown
@@ -2985,6 +2988,9 @@ dBernoulliModelPrior <- function(k, n, prob = 0.5, log = FALSE) {
   identical(state[nms], options[nms])
 }
 
+.BANOVAmodelTermsUnchanged <- function(state, options) {
+  identical(state[["modelTerms"]], options[["modelTerms"]])
+}
 
 # HF formulas ----
 .BANOVAgetFormulaComponents <- function(x, what = c("components", "variables")) {

--- a/inst/qml/common/bayesian/DefaultOptions.qml
+++ b/inst/qml/common/bayesian/DefaultOptions.qml
@@ -55,6 +55,20 @@ Group
 		RadioButton { value: "nullModelTop"; label: qsTr("Compare to null model")					}
 	}
 
+	RadioButtonGroup
+	{
+		name: "modelsShown"
+		title: qsTr("Limit No. Models Shown")
+		RadioButton { value: "unlimited"; label: qsTr("No") }
+		RadioButton {
+			value: "limited"
+			label: qsTr("Yes, show best")
+			checked: true
+			childrenOnSameRow: true
+			IntegerField { name: "numModelsShown"; defaultValue: 10; min: 1}
+		}
+	}
+
 	GroupBox
 	{
 		title: qsTr("Plots")

--- a/tests/testthat/helper-banova.R
+++ b/tests/testthat/helper-banova.R
@@ -2,6 +2,7 @@
 initOpts <- function(analysisName) {
   options <- jaspTools::analysisOptions(analysisName)
   options <- addCommonQMLoptions(options)
+  options$modelsShown <- "unlimited"
 
   # avoid that BayesFactor shows progress bars
   options("BFprogress" = FALSE)

--- a/tests/testthat/test-anovabayesian.R
+++ b/tests/testthat/test-anovabayesian.R
@@ -226,3 +226,61 @@ test_that("Model prior changes posterior model probabilities", {
   }
   if (createReference) saveRDS(reference, referencePath)
 })
+
+test_that("Changing the number of models shown affects the main table", {
+  set.seed(0)
+  options <- initOpts("AnovaBayesian")
+  options$dependent <- "contNormal"
+  options$fixedFactors <- c("facGender", "facFive", "facExperim")
+  options$modelTerms <- list(
+    list(components="facGender", isNuisance=FALSE),
+    list(components="facFive", isNuisance=FALSE),
+    list(components="facExperim", isNuisance=FALSE),
+    list(components=c("facGender", "facFive"), isNuisance=FALSE),
+    list(components=c("facGender", "facExperim"), isNuisance=FALSE),
+    list(components=c("facExperim", "facFive"), isNuisance=FALSE),
+    list(components=c("facGender", "facExperim", "facFive"), isNuisance=FALSE)
+  )
+
+  options$modelsShown <- "limited"
+  options$numModelsShown <- 5
+
+  results <- jaspTools::runAnalysis("AnovaBayesian", "test.csv", options)
+  table <- results[["results"]][["tableModelComparison"]][["data"]]
+
+  jaspTools::expect_equal_tables(table,
+                                 list(1, 13.3659218116967, "facGender", 0.0526315789473684, 0.426128774149797,
+                                      "", 0.523794362759307, 5.17210247921735, "Null model", 0.0526315789473684,
+                                      0.223203849709198, 0.00991710759730765, 0.181670581429487, 1.51039873056377,
+                                      "facGender + facExperim", 0.0526315789473684, 0.0774150621636282,
+                                      14.3301775340925, 0.160926125807685, 1.32523271745499, "facGender + facFive",
+                                      0.0526315789473684, 0.0685752527191049, 23.0898719232616, 0.116409805929351,
+                                      0.939504896110524, "facExperim", 0.0526315789473684, 0.0496055678996901,
+                                      0.0269112294974812), label = "Table with 5 rows")
+
+  options$modelsShown <- "limited"
+  options$numModelsShown <- 10
+
+  results <- jaspTools::runAnalysis("AnovaBayesian", "test.csv", options)
+  table <- results[["results"]][["tableModelComparison"]][["data"]]
+
+  jaspTools::expect_equal_tables(table,
+                                 list(1, 13.5401945213762, "facGender", 0.0526315789473684, 0.429299651661927,
+                                      "", 0.523794362759307, 5.22175350578976, "Null model", 0.0526315789473684,
+                                      0.224864737475051, 0.00991710759730765, 0.170863908644435, 1.42484787623232,
+                                      "facGender + facExperim", 0.0526315789473684, 0.0733518164626514,
+                                      7.64535614840947, 0.16705375323206, 1.39061999288634, "facGender + facFive",
+                                      0.0526315789473684, 0.0717161180713408, 13.4935759252231, 0.116409805929351,
+                                      0.946863619476086, "facExperim", 0.0526315789473684, 0.0499746891355029,
+                                      0.0269112294974812, 0.0902952358051223, 0.725884830441666, "facGender + facExperim + facGender<unicode><unicode><unicode>facExperim",
+                                      0.0526315789473684, 0.0387637132778706, 22.7829909603318, 0.0791076920342147,
+                                      0.632786277848988, "facFive", 0.0526315789473684, 0.0339609046340674,
+                                      0.00994061596714849, 0.0570470263884217, 0.451891785202431,
+                                      "facGender + facFive + facGender<unicode><unicode><unicode>facFive",
+                                      0.0526315789473684, 0.0244902685568982, 7.29922242520545, 0.0252985039010556,
+                                      0.197637975104202, "facGender + facFive + facExperim", 0.0526315789473684,
+                                      0.0108606389122911, 9.56328348447552, 0.0208881223923882, 0.16287125549643,
+                                      "facGender + facFive + facExperim + facFive<unicode><unicode><unicode>facExperim",
+                                      0.0526315789473684, 0.00896726366692393, 7.67806876653366), label = "Table with 10 rows")
+
+})


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/2066

~I also noticed that the Bayesian repeated measures ANOVA does not update when adding between-subjects factors. I think this is unrelated but I still have to double-check. If it is unrelated I'll fix that in a separate PR.~

The state issue was my bad it should be fixed now.

The changes got a little bit bigger than intended because I changed the `internalTable` from a matrix to a `data.frame`.

Also, the commit messages really suck, please don't look at them :sweat_smile: