### PR TITLE
Change includeAnovaTables to anovaTables in manova

### DIFF
--- a/R/manova.R
+++ b/R/manova.R
@@ -173,7 +173,7 @@ Manova <- function(jaspResults, dataset = NULL, options) {
                                                  "testPillai", "testWilks",
                                                  "testHotellingLawley", "testRoy", 
                                                  "includeIntercept", "vovkSellke",
-                                                 "modelTerms", "includeAnovaTables"))
+                                                 "modelTerms", "anovaTables"))
   
   # Return results object
   return(results)
@@ -188,7 +188,7 @@ Manova <- function(jaspResults, dataset = NULL, options) {
   
   manovaContainer$dependOn(c("dependent", "fixedFactors", "testPillai", "testWilks",
                          "testHotellingLawley", "testRoy", "includeIntercept",
-                         "vovkSellke", "modelTerms", "includeAnovaTables"))
+                         "vovkSellke", "modelTerms", "anovaTables"))
 
   # Set up the different tests for Manova
   allTests <- c("Pillai", "Wilks", "Hotelling-Lawley", "Roy") 
@@ -242,14 +242,14 @@ Manova <- function(jaspResults, dataset = NULL, options) {
 
 .uniAnovaTables <- function(jaspResults, dataset, options, manovaResults, ready) {
   
-  if (!is.null(jaspResults[["anovaContainer"]]) || !options$includeAnovaTables) return()
+  if (!is.null(jaspResults[["anovaContainer"]]) || !options$anovaTables) return()
   
   anovaContainer <- createJaspContainer(title = gettext("ANOVA"))
   jaspResults[["anovaContainer"]] <- anovaContainer
   
   anovaContainer$dependOn(c("dependent", "fixedFactors", "testPillai", "testWilks",
                              "testHotellingLawley", "testRoy", "includeIntercept",
-                             "vovkSellke", "modelTerms", "includeAnovaTables"))
+                             "vovkSellke", "modelTerms", "anovaTables"))
   
   anovaResults <- manovaResults$anova
 

--- a/tests/testthat/test-verified-manova.R
+++ b/tests/testthat/test-verified-manova.R
@@ -12,7 +12,7 @@ options$testPillai          <- TRUE
 options$testWilks           <- TRUE
 options$testHotellingLawley <- TRUE
 options$testRoy             <- TRUE
-options$includeAnovaTables  <- TRUE
+options$anovaTables         <- TRUE
 results <- jaspTools::runAnalysis("Manova", "manova_ocd.csv", options)
 
 # https://jasp-stats.github.io/jasp-verification-project/anova.html#manova


### PR DESCRIPTION
The includeAnovaTables option was changed to anovaTables in QML, but not in R
@Kucharssim I see also that VovkSellkeMPR was changed to vovkSellke, but here there are many functions involved, so maybe someone who understand better this code should do that.