### PR TITLE
fix post-hoc in rm anova

### DIFF
--- a/R/anovarepeatedmeasures.R
+++ b/R/anovarepeatedmeasures.R
@@ -989,7 +989,6 @@ AnovaRepeatedMeasures <- function(jaspResults, dataset = NULL, options) {
   postHocVariablesListV <- unname(lapply(postHocVariables, .v))
   variables <- unname(sapply(postHocVariables, function(x) paste(.v(x), collapse = ":")))
 
-  options$postHocTestsSidak <- FALSE
   for (postHocVarIndex in 1:length(postHocVariables)) {
 
     thisVarName <- paste(postHocVariables[[postHocVarIndex]], collapse = " \u273B ")

--- a/R/anovarepeatedmeasures.R
+++ b/R/anovarepeatedmeasures.R
@@ -1190,7 +1190,8 @@ AnovaRepeatedMeasures <- function(jaspResults, dataset = NULL, options) {
   if (options$postHocCorrectionHolm)
     postHocTable$addColumnInfo(name="holm", title=gettext("p<sub>holm</sub>"), type="pvalue")
 
-  if (options$postHocCorrectionSidak)
+  # Sidak option does not exist in RM-ANOVA
+  if (isTRUE(options$postHocCorrectionSidak))
     postHocTable$addColumnInfo(name="sidak", title=gettext("p<sub>sidak</sub>"), type="pvalue")
 
 
@@ -1566,7 +1567,7 @@ AnovaRepeatedMeasures <- function(jaspResults, dataset = NULL, options) {
       friedmanTable$setError(gettextf("Not an unreplicated complete block design."))
       return()
     }
-    
+
     t <- nlevels(groups)
     b <- nlevels(blocks)
     r <- unique(table(groups))


### PR DESCRIPTION
The function is reused for AN(C)OVA and RM ANOVA. However, RM ANOVA does not have the Šidák option so we need to make sure not to crash because of `argument is of length zero`