### PR TITLE
Revert restriktor to version 0.3-500

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,4 +33,5 @@ Remotes:
   jasp-stats/jaspBase,
   jasp-stats/jaspDescriptives,
   jasp-stats/jaspGraphs,
-  jasp-stats/jaspTTests
+  jasp-stats/jaspTTests,
+  Kucharssim/restriktor

--- a/inst/help/goric/restriktorSyntax.md
+++ b/inst/help/goric/restriktorSyntax.md
@@ -109,7 +109,7 @@ Constraints on coefficients of within-subject factors can be specified similar t
 
 If both within- and between-subjects terms are in the model, their coefficients can also only be accessed through the dot operator `.`; the within-subject terms preceed those that are between-subjects, e.g.
 
-`withinSubjectsLevel1.betweenFactorLevel1`.
+`withinSubjectsCell.betweenFactorLevel1`.
 
 Including or excluding the intercept has the same implications for the between-subject terms (and covariates) as in AN(C)OVA. There is no intercept for the within-subject terms. 
 


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-test-release/issues/2303

This is just a short-term fix for the next release, in the long term we want to update the code to work with the newer version; there is another issue for that here: https://github.com/jasp-stats/INTERNAL-jasp/issues/2315

@maltelueken:
> Ah ok, then we should also update the help window according to the changes I guess?

It seems to me that the file is already up to date; the only thing that mislead was the example which I now fixed. Does this seem ok to you or do you see other instances where the help file is innacurate?
