### PR TITLE
Fix text overlay on monospaced font

### DIFF
--- a/inst/qml/common/classical/OrderRestrictions.qml
+++ b/inst/qml/common/classical/OrderRestrictions.qml
@@ -33,7 +33,10 @@ Section
 	
 	Text
 	{
-		Layout.columnSpan:	2
+		Layout.columnSpan:      2
+		Layout.preferredWidth:  parent.width
+		wrapMode:               Text.WordWrap
+
 		text:				qsTr("Enter each restriction of one hypothesis on a new line, e.g., \nfactorLow == factorMid\nfactorMid < factorHigh\nwhere 'factor' is the factor (or covariate) name and 'Low'/'Mid'/'High' are the factor level names.\nClick on the 'plus' icon to add more hypotheses. \nClick the information icon for more examples.")
 	}
 


### PR DESCRIPTION
like Fira Code font previous:

![image](https://user-images.githubusercontent.com/10348402/225804352-c25d698c-3af0-4aad-8d99-1d2542a25197.png)

Now it will wrap word.

_i18n test will be fixed in another PR._