### PR TITLE
Better error message normality in MANOVA, update column label contrast effect size

### DIFF
--- a/R/commonAnovaBayesian.R
+++ b/R/commonAnovaBayesian.R
@@ -2731,7 +2731,7 @@ BANOVAcomputMatchedInclusion <- function(effectNames, effects.matrix, interactio
     idx <- is.na(gg)
     if (all(idx)) {
       # this means that either the posterior sampling failed or the input data is bogus.
-      .quitAnalysis(gettext("All predictions had zero variance. Check the predictors for anomalies or increase the number of posterior samples."))
+      .quitAnalysis(gettext("All predictions had zero variance. Check the predictors/DV for anomalies or increase the number of posterior samples."))
     } else {
       # this shouldn't happen, but is necessary because otherwise stuff will crash downstream.
       gg[is.na(gg)] <- mean(gg, na.rm = TRUE)

--- a/R/manova.R
+++ b/R/manova.R
@@ -287,10 +287,13 @@ ManovaInternal <- function(jaspResults, dataset = NULL, options) {
 
   if (isTryError(tryResult)) {
     result <- NULL
-    if (grepl(tryResult[[1]], pattern = "singular"))
+    if (grepl(tryResult[[1]], pattern = "singular")) {
       errors <- gettext("The design matrix is not invertible. This might be due to collinear dependent variables.")
-    else
+    } else if (grepl(tryResult[[1]], pattern = "sample size")) {
+      errors <- gettext("Results unavailable due to sample size (must be between 3 and 5000) or perfect correlations.")
+    } else {
       errors <- .extractErrorMessage(tryResult)
+    }
   } else {
     errors <- NULL
   }

--- a/inst/qml/common/classical/Contrasts.qml
+++ b/inst/qml/common/classical/Contrasts.qml
@@ -44,6 +44,6 @@ Section
 	}
 	CheckBox
 	{
-		name: "contrastEffectSize"; label: qsTr("Effect size")
+		name: "contrastEffectSize"; label: qsTr("Effect size (cohen's d)")
 	}
 }

--- a/renv.lock
+++ b/renv.lock
@@ -1215,7 +1215,7 @@
       "RemoteHost": "api.github.com",
       "RemoteUsername": "jasp-stats",
       "RemoteRepo": "jaspDescriptives",
-      "RemoteSha": "325177034dcd7456d0eecb3317cdde9dceecf66c"
+      "RemoteSha": "59da7037bbf96a5b4433e0fd02cec3f6cb930014"
     },
     "jaspGraphs": {
       "Package": "jaspGraphs",
@@ -1258,7 +1258,7 @@
       "RemoteHost": "api.github.com",
       "RemoteUsername": "jasp-stats",
       "RemoteRepo": "jaspTTests",
-      "RemoteSha": "603db7bcc6e4560eb39f446717a7fbb30eba6807"
+      "RemoteSha": "980bdd6e099ca5fb981975660758b1a0a7c09af4"
     },
     "jpeg": {
       "Package": "jpeg",


### PR DESCRIPTION
Indicate more clearly that the effect size in contrasts is cohen's d
Fix https://github.com/jasp-stats/jasp-test-release/issues/2752 